### PR TITLE
Model Cleanup

### DIFF
--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -51,13 +51,6 @@ abstract class BaseModel
 	public $pager;
 
 	/**
-	 * Name of database table
-	 *
-	 * @var string
-	 */
-	protected $table;
-
-	/**
 	 * Last insert ID
 	 *
 	 * @var integer|string
@@ -1361,20 +1354,6 @@ abstract class BaseModel
 			default:
 				throw ModelException::forNoDateFormat(static::class);
 		}
-	}
-
-	/**
-	 * Specify the table associated with a model
-	 *
-	 * @param string $table Table
-	 *
-	 * @return $this
-	 */
-	public function setTable(string $table)
-	{
-		$this->table = $table;
-
-		return $this;
 	}
 
 	/**

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -28,17 +28,18 @@ use stdClass;
 /**
  * Class Model
  *
- * The Model class provides a number of convenient features that
- * makes working with a database table less painful.
+ * The BaseModel class provides a number of convenient features that
+ * makes working with a databases less painful. Extending this class
+ * provide means of implementing various database systems
  *
  * It will:
- *      - automatically connect to database
- *      - allow intermingling calls between db connection, the builder,
- *          and methods in this class.
  *      - simplifies pagination
- *      - removes the need to use Result object directly in most cases
  *      - allow specifying the return type (array, object, etc) with each call
+ *      - automatically set and update timestamps
+ *      - handle soft deletes
  *      - ensure validation is run against objects when saving items
+ *      - process various callbacks
+ *      - allow intermingling calls to the db connection
  */
 abstract class BaseModel
 {

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -351,7 +351,7 @@ abstract class BaseModel
 
 		$eventData = [
 			'id'        => $id,
-			'data'      => $this->_find($singleton, $id),
+			'data'      => $this->doFind($singleton, $id),
 			'method'    => 'find',
 			'singleton' => $singleton,
 		];
@@ -377,7 +377,7 @@ abstract class BaseModel
 	 *
 	 * @return array|object|null    The resulting row of data, or null.
 	 */
-	abstract protected function _find(bool $singleton, $id = null);
+	abstract protected function doFind(bool $singleton, $id = null);
 
 	/**
 	 * Fetches the column of database from $this->table
@@ -394,7 +394,7 @@ abstract class BaseModel
 			throw DataException::forFindColumnHaveMultipleColumns();
 		}
 
-		$resultSet = $resultSet = $this->_findColumn($columnName);
+		$resultSet = $resultSet = $this->doFindColumn($columnName);
 
 		return $resultSet ? array_column($resultSet, $columnName) : null;
 	}
@@ -407,7 +407,7 @@ abstract class BaseModel
 	 * @return array|null   The resulting row of data, or null if no data found.
 	 * @throws DataException Data Exception.
 	 */
-	abstract protected function _findColumn(string $columnName);
+	abstract protected function doFindColumn(string $columnName);
 
 	/**
 	 * Works with the current Query Builder instance to return
@@ -437,7 +437,7 @@ abstract class BaseModel
 		}
 
 		$eventData = [
-			'data'      => $this->_findAll($limit, $offset),
+			'data'      => $this->doFindAll($limit, $offset),
 			'limit'     => $limit,
 			'offset'    => $offset,
 			'method'    => 'findAll',
@@ -465,7 +465,7 @@ abstract class BaseModel
 	 *
 	 * @return array
 	 */
-	abstract protected function _findAll(int $limit = 0, int $offset = 0);
+	abstract protected function doFindAll(int $limit = 0, int $offset = 0);
 
 	/**
 	 * Returns the first row of the result set. Will take any previous
@@ -490,7 +490,7 @@ abstract class BaseModel
 		}
 
 		$eventData = [
-			'data'      => $this->_first(),
+			'data'      => $this->doFirst(),
 			'method'    => 'first',
 			'singleton' => true,
 		];
@@ -513,7 +513,7 @@ abstract class BaseModel
 	 *
 	 * @return array|object|null
 	 */
-	abstract protected function _first();
+	abstract protected function doFirst();
 
 	/**
 	 * Captures the builder's set() method so that we can validate the
@@ -554,7 +554,7 @@ abstract class BaseModel
 			return true;
 		}
 
-		return $this->_save($data);
+		return $this->doSave($data);
 	}
 
 	/**
@@ -568,7 +568,7 @@ abstract class BaseModel
 	 *
 	 * @return boolean
 	 */
-	abstract protected function _save($data): bool;
+	abstract protected function doSave($data): bool;
 
 	/**
 	 * Takes a class an returns an array of it's public and protected
@@ -745,7 +745,7 @@ abstract class BaseModel
 			$eventData = $this->trigger('beforeInsert', $eventData);
 		}
 
-		$result = $this->_insert($eventData['data'], $escape);
+		$result = $this->doInsert($eventData['data'], $escape);
 
 		$eventData = [
 			'id'     => $this->insertID,
@@ -780,7 +780,7 @@ abstract class BaseModel
 	 *
 	 * @return object|integer|string|false
 	 */
-	abstract protected function _insert($data, ?bool $escape = null);
+	abstract protected function doInsert($data, ?bool $escape = null);
 
 	/**
 	 * Compiles batch insert strings and runs the queries, validating each row prior.
@@ -840,7 +840,7 @@ abstract class BaseModel
 			}
 		}
 
-		return $this->_insertBatch($set, $escape, $batchSize, $testing);
+		return $this->doInsertBatch($set, $escape, $batchSize, $testing);
 	}
 
 	/**
@@ -854,7 +854,7 @@ abstract class BaseModel
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
 	 * @throws ReflectionException ReflectionException.
 	 */
-	abstract protected function _insertBatch(
+	abstract protected function doInsertBatch(
 		array $set = null,
 		bool $escape = null,
 		int $batchSize = 100,
@@ -942,7 +942,7 @@ abstract class BaseModel
 		$eventData = [
 			'id'     => $id,
 			'data'   => $eventData['data'],
-			'result' => $this->_update($id, $eventData['data']),
+			'result' => $this->doUpdate($id, $eventData['data']),
 		];
 
 		if ($this->tempAllowCallbacks)
@@ -965,7 +965,7 @@ abstract class BaseModel
 	 *
 	 * @return boolean
 	 */
-	abstract protected function _update($id = null, $data = null, ?bool $escape = null): bool;
+	abstract protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool;
 
 	/**
 	 * Update_Batch
@@ -1029,7 +1029,7 @@ abstract class BaseModel
 			}
 		}
 
-		return $this->_updateBatch($set, $index, $batchSize, $returnSQL);
+		return $this->doUpdateBatch($set, $index, $batchSize, $returnSQL);
 	}
 
 	/**
@@ -1046,7 +1046,7 @@ abstract class BaseModel
 	 * @throws DatabaseException DatabaseException.
 	 * @throws ReflectionException ReflectionException.
 	 */
-	abstract protected function _updateBatch(
+	abstract protected function doUpdateBatch(
 		array $set = null,
 		string $index = null,
 		int $batchSize = 100,
@@ -1084,7 +1084,7 @@ abstract class BaseModel
 			'id'     => $id,
 			'data'   => null,
 			'purge'  => $purge,
-			'result' => $this->_delete($id, $purge),
+			'result' => $this->doDelete($id, $purge),
 		];
 
 		if ($this->tempAllowCallbacks)
@@ -1107,7 +1107,7 @@ abstract class BaseModel
 	 * @return object|boolean
 	 * @throws DatabaseException DatabaseException.
 	 */
-	abstract protected function _delete($id = null, bool $purge = false);
+	abstract protected function doDelete($id = null, bool $purge = false);
 
 	/**
 	 * Permanently deletes all rows that have been marked as deleted
@@ -1122,7 +1122,7 @@ abstract class BaseModel
 			return true;
 		}
 
-		return $this->_purgeDeleted();
+		return $this->doPurgeDeleted();
 	}
 
 	/**
@@ -1131,7 +1131,7 @@ abstract class BaseModel
 	 *
 	 * @return boolean|mixed
 	 */
-	abstract protected function _purgeDeleted();
+	abstract protected function doPurgeDeleted();
 
 	/**
 	 * Sets $useSoftDeletes value so that we can temporarily override
@@ -1157,7 +1157,7 @@ abstract class BaseModel
 	public function onlyDeleted()
 	{
 		$this->tempUseSoftDeletes = false;
-		$this->_onlyDeleted();
+		$this->doOnlyDeleted();
 
 		return $this;
 	}
@@ -1168,7 +1168,7 @@ abstract class BaseModel
 	 *
 	 * @return void
 	 */
-	abstract protected function _onlyDeleted();
+	abstract protected function doOnlyDeleted();
 
 	/**
 	 * Replace
@@ -1188,7 +1188,7 @@ abstract class BaseModel
 			return false;
 		}
 
-		return $this->_replace($data, $returnSQL);
+		return $this->doReplace($data, $returnSQL);
 	}
 
 	/**
@@ -1201,7 +1201,7 @@ abstract class BaseModel
 	 *
 	 * @return mixed
 	 */
-	abstract protected function _replace(array $data = null, bool $returnSQL = false);
+	abstract protected function doReplace(array $data = null, bool $returnSQL = false);
 
 	//--------------------------------------------------------------------
 	// Utility
@@ -1399,7 +1399,7 @@ abstract class BaseModel
 			}
 		}
 
-		$error = $this->_errors();
+		$error = $this->doErrors();
 
 		return $error['message'] ?? null;
 	}
@@ -1409,7 +1409,7 @@ abstract class BaseModel
 	 *
 	 * @return array|null
 	 */
-	abstract protected function _errors();
+	abstract protected function doErrors();
 
 	/**
 	 * It could be used when you have to change default or override current allowed fields.

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -1,0 +1,1832 @@
+<?php
+
+/**
+ * This file is part of the CodeIgniter 4 framework.
+ *
+ * (c) CodeIgniter Foundation <admin@codeigniter.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CodeIgniter;
+
+use Closure;
+use CodeIgniter\Database\BaseResult;
+use CodeIgniter\Database\ConnectionInterface;
+use CodeIgniter\Database\Exceptions\DatabaseException;
+use CodeIgniter\Database\Exceptions\DataException;
+use CodeIgniter\Exceptions\ModelException;
+use CodeIgniter\I18n\Time;
+use CodeIgniter\Pager\Pager;
+use CodeIgniter\Validation\ValidationInterface;
+use Config\Services;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+use stdClass;
+
+/**
+ * Class Model
+ *
+ * The Model class provides a number of convenient features that
+ * makes working with a database table less painful.
+ *
+ * It will:
+ *      - automatically connect to database
+ *      - allow intermingling calls between db connection, the builder,
+ *          and methods in this class.
+ *      - simplifies pagination
+ *      - removes the need to use Result object directly in most cases
+ *      - allow specifying the return type (array, object, etc) with each call
+ *      - ensure validation is run against objects when saving items
+ */
+abstract class BaseModel
+{
+	/**
+	 * The table's primary key.
+	 *
+	 * @var string
+	 */
+	protected $primaryKey = 'id';
+
+	/**
+	 * Pager instance.
+	 * Populated after calling $this->paginate()
+	 *
+	 * @var Pager
+	 */
+	public $pager;
+
+	/**
+	 * Name of database table
+	 *
+	 * @var string
+	 */
+	protected $table;
+
+	/**
+	 * Last insert ID
+	 *
+	 * @var integer|string
+	 */
+	protected $insertID = 0;
+
+	/**
+	 * The Database connection group that
+	 * should be instantiated.
+	 *
+	 * @var string
+	 */
+	protected $DBGroup;
+
+	/**
+	 * The format that the results should be returned as.
+	 * Will be overridden if the as* methods are used.
+	 *
+	 * @var string
+	 */
+	protected $returnType = 'array';
+
+	/**
+	 * If this model should use "softDeletes" and
+	 * simply set a date when rows are deleted, or
+	 * do hard deletes.
+	 *
+	 * @var boolean
+	 */
+	protected $useSoftDeletes = false;
+
+	/**
+	 * An array of field names that are allowed
+	 * to be set by the user in inserts/updates.
+	 *
+	 * @var array
+	 */
+	protected $allowedFields = [];
+
+	/**
+	 * If true, will set created_at, and updated_at
+	 * values during insert and update routines.
+	 *
+	 * @var boolean
+	 */
+	protected $useTimestamps = false;
+
+	/**
+	 * The type of column that created_at and updated_at
+	 * are expected to.
+	 *
+	 * Allowed: 'datetime', 'date', 'int'
+	 *
+	 * @var string
+	 *
+	 * @todo make it more generic to be used by other models
+	 */
+	protected $dateFormat = 'datetime';
+
+	/**
+	 * The column used for insert timestamps
+	 *
+	 * @var string
+	 */
+	protected $createdField = 'created_at';
+
+	/**
+	 * The column used for update timestamps
+	 *
+	 * @var string
+	 */
+	protected $updatedField = 'updated_at';
+
+	/**
+	 * Used by withDeleted to override the
+	 * model's softDelete setting.
+	 *
+	 * @var boolean
+	 */
+	protected $tempUseSoftDeletes;
+
+	/**
+	 * The column used to save soft delete state
+	 *
+	 * @var string
+	 */
+	protected $deletedField = 'deleted_at';
+
+	/**
+	 * Used by asArray and asObject to provide
+	 * temporary overrides of model default.
+	 *
+	 * @var string
+	 */
+	protected $tempReturnType;
+
+	/**
+	 * Whether we should limit fields in inserts
+	 * and updates to those available in $allowedFields or not.
+	 *
+	 * @var boolean
+	 */
+	protected $protectFields = true;
+
+	/**
+	 * Database Connection
+	 *
+	 * @var ConnectionInterface
+	 *
+	 * @todo check if Interface can be used for NO-SQL
+	 */
+	protected $db;
+
+	/**
+	 * Rules used to validate data in insert, update, and save methods.
+	 * The array must match the format of data passed to the Validation
+	 * library.
+	 *
+	 * @var array|string
+	 */
+	protected $validationRules = [];
+
+	/**
+	 * Contains any custom error messages to be
+	 * used during data validation.
+	 *
+	 * @var array
+	 */
+	protected $validationMessages = [];
+
+	/**
+	 * Skip the model's validation. Used in conjunction with skipValidation()
+	 * to skip data validation for any future calls.
+	 *
+	 * @var boolean
+	 */
+	protected $skipValidation = false;
+
+	/**
+	 * Whether rules should be removed that do not exist
+	 * in the passed in data. Used between inserts/updates.
+	 *
+	 * @var boolean
+	 */
+	protected $cleanValidationRules = true;
+
+	/**
+	 * Our validator instance.
+	 *
+	 * @var ValidationInterface
+	 */
+	protected $validation;
+
+	/*
+	 * Callbacks.
+	 *
+	 * Each array should contain the method names (within the model)
+	 * that should be called when those events are triggered.
+	 *
+	 * "Update" and "delete" methods are passed the same items that
+	 * are given to their respective method.
+	 *
+	 * "Find" methods receive the ID searched for (if present), and
+	 * 'afterFind' additionally receives the results that were found.
+	 */
+
+	/**
+	 * Whether to trigger the defined callbacks
+	 *
+	 * @var boolean
+	 */
+	protected $allowCallbacks = true;
+
+	/**
+	 * Used by allowCallbacks() to override the
+	 * model's allowCallbacks setting.
+	 *
+	 * @var boolean
+	 */
+	protected $tempAllowCallbacks;
+
+	/**
+	 * Callbacks for beforeInsert
+	 *
+	 * @var array
+	 */
+	protected $beforeInsert = [];
+
+	/**
+	 * Callbacks for afterInsert
+	 *
+	 * @var array
+	 */
+	protected $afterInsert = [];
+
+	/**
+	 * Callbacks for beforeUpdate
+	 *
+	 * @var array
+	 */
+	protected $beforeUpdate = [];
+
+	/**
+	 * Callbacks for afterUpdate
+	 *
+	 * @var array
+	 */
+	protected $afterUpdate = [];
+
+	/**
+	 * Callbacks for beforeFind
+	 *
+	 * @var array
+	 */
+	protected $beforeFind = [];
+
+	/**
+	 * Callbacks for afterFind
+	 *
+	 * @var array
+	 */
+	protected $afterFind = [];
+
+	/**
+	 * Callbacks for beforeDelete
+	 *
+	 * @var array
+	 */
+	protected $beforeDelete = [];
+
+	/**
+	 * Callbacks for afterDelete
+	 *
+	 * @var array
+	 */
+	protected $afterDelete = [];
+
+	/**
+	 * Holds information passed in via 'set'
+	 * so that we can capture it (not the builder)
+	 * and ensure it gets validated first.
+	 *
+	 * @var array
+	 */
+	protected $tempData = [];
+
+	/**
+	 * Model constructor.
+	 *
+	 * @param object|null              $db         DB Connection
+	 * @param ValidationInterface|null $validation Validation
+	 *
+	 * @phpstan-ignore-next-line
+	 */
+	public function __construct(object &$db = null, ValidationInterface $validation = null)
+	{
+		$this->tempReturnType     = $this->returnType;
+		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+		$this->validation         = $validation ?? Services::validation(null, false);
+	}
+
+	//--------------------------------------------------------------------
+	// CRUD & FINDERS
+	//--------------------------------------------------------------------
+
+	/**
+	 * Fetches the row of database from $this->table with a primary key
+	 * matching $id.
+	 *
+	 * @param array|integer|string|null $id One primary key or an array of primary keys
+	 *
+	 * @return array|object|null    The resulting row of data, or null.
+	 */
+	public function find($id = null)
+	{
+		$singleton = is_numeric($id) || is_string($id);
+
+		if ($this->tempAllowCallbacks)
+		{
+			// Call the before event and check for a return
+			$eventData = $this->trigger('beforeFind', [
+				'id'        => $id,
+				'method'    => 'find',
+				'singleton' => $singleton,
+			]);
+
+			if (! empty($eventData['returnData']))
+			{
+				return $eventData['data'];
+			}
+		}
+
+		$eventData = [
+			'id'        => $id,
+			'data'      => $this->_find($singleton, $id),
+			'method'    => 'find',
+			'singleton' => $singleton,
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('afterFind', $eventData);
+		}
+
+		$this->tempReturnType     = $this->returnType;
+		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+
+		return $eventData['data'];
+	}
+
+	/**
+	 * Fetches the row of database from $this->table with a primary key
+	 * matching $id. This methods works only with dbCalls
+	 *
+	 * @param boolean                   $singleton Single or multiple results
+	 * @param array|integer|string|null $id        One primary key or an array of primary keys
+	 *
+	 * @return array|object|null    The resulting row of data, or null.
+	 */
+	protected abstract function _find(bool $singleton, $id = null);
+
+	/**
+	 * Fetches the column of database from $this->table
+	 *
+	 * @param string $columnName Column Name
+	 *
+	 * @return array|null   The resulting row of data, or null if no data found.
+	 * @throws DataException Data Exception.
+	 */
+	public function findColumn(string $columnName)
+	{
+		if (strpos($columnName, ',') !== false)
+		{
+			throw DataException::forFindColumnHaveMultipleColumns();
+		}
+
+		$resultSet = $resultSet = $this->_findColumn($columnName);
+
+		return $resultSet ? array_column($resultSet, $columnName) : null;
+	}
+
+	/**
+	 * Fetches the column of database from $this->table
+	 *
+	 * @param string $columnName Column Name
+	 *
+	 * @return array|null   The resulting row of data, or null if no data found.
+	 * @throws DataException Data Exception.
+	 */
+	protected abstract function _findColumn(string $columnName);
+
+	/**
+	 * Works with the current Query Builder instance to return
+	 * all results, while optionally limiting them.
+	 *
+	 * @param integer $limit  Limit
+	 * @param integer $offset Offset
+	 *
+	 * @return array
+	 */
+	public function findAll(int $limit = 0, int $offset = 0)
+	{
+		if ($this->tempAllowCallbacks)
+		{
+			// Call the before event and check for a return
+			$eventData = $this->trigger('beforeFind', [
+				'method'    => 'findAll',
+				'limit'     => $limit,
+				'offset'    => $offset,
+				'singleton' => false,
+			]);
+
+			if (! empty($eventData['returnData']))
+			{
+				return $eventData['data'];
+			}
+		}
+
+		$eventData = [
+			'data'      => $this->_findAll($limit, $offset),
+			'limit'     => $limit,
+			'offset'    => $offset,
+			'method'    => 'findAll',
+			'singleton' => false,
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('afterFind', $eventData);
+		}
+
+		$this->tempReturnType     = $this->returnType;
+		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+
+		return $eventData['data'];
+	}
+
+	/**
+	 * Works with the current Query Builder instance to return
+	 * all results, while optionally limiting them.
+	 *
+	 * @param integer $limit  Limit
+	 * @param integer $offset Offset
+	 *
+	 * @return array
+	 */
+	protected abstract function _findAll(int $limit = 0, int $offset = 0);
+
+	/**
+	 * Returns the first row of the result set. Will take any previous
+	 * Query Builder calls into account when determining the result set.
+	 *
+	 * @return array|object|null
+	 */
+	public function first()
+	{
+		if ($this->tempAllowCallbacks)
+		{
+			// Call the before event and check for a return
+			$eventData = $this->trigger('beforeFind', [
+				'method'    => 'first',
+				'singleton' => true,
+			]);
+
+			if (! empty($eventData['returnData']))
+			{
+				return $eventData['data'];
+			}
+		}
+
+		$eventData = [
+			'data'      => $this->_first(),
+			'method'    => 'first',
+			'singleton' => true,
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('afterFind', $eventData);
+		}
+
+		$this->tempReturnType     = $this->returnType;
+		$this->tempUseSoftDeletes = $this->useSoftDeletes;
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+
+		return $eventData['data'];
+	}
+
+	/**
+	 * Returns the first row of the result set. Will take any previous
+	 * Query Builder calls into account when determining the result set.
+	 *
+	 * @return array|object|null
+	 */
+	protected abstract function _first();
+
+	/**
+	 * Captures the builder's set() method so that we can validate the
+	 * data here. This allows it to be used with any of the other
+	 * builder methods and still get validated data, like replace.
+	 *
+	 * @param mixed       $key    Field name, or an array of field/value pairs
+	 * @param string|null $value  Field value, if $key is a single field
+	 * @param boolean     $escape Whether to escape values and identifiers
+	 *
+	 * @return $this
+	 */
+	public function set($key, ?string $value = '', bool $escape = null)
+	{
+		$data = is_array($key) ? $key : [$key => $value];
+
+		$this->tempData['escape'] = $escape;
+		$this->tempData['data']   = array_merge($this->tempData['data'] ?? [], $data);
+
+		return $this;
+	}
+
+	/**
+	 * A convenience method that will attempt to determine whether the
+	 * data should be inserted or updated. Will work with either
+	 * an array or object. When using with custom class objects,
+	 * you must ensure that the class will provide access to the class
+	 * variables, even if through a magic method.
+	 *
+	 * @param array|object $data Data
+	 *
+	 * @return boolean
+	 */
+	public function save($data): bool
+	{
+		if (empty($data))
+		{
+			return true;
+		}
+
+		return $this->_save($data);
+	}
+
+	/**
+	 * A convenience method that will attempt to determine whether the
+	 * data should be inserted or updated. Will work with either
+	 * an array or object. When using with custom class objects,
+	 * you must ensure that the class will provide access to the class
+	 * variables, even if through a magic method.
+	 *
+	 * @param array|object $data Data
+	 *
+	 * @return boolean
+	 */
+	protected abstract function _save($data): bool;
+
+	/**
+	 * Takes a class an returns an array of it's public and protected
+	 * properties as an array suitable for use in creates and updates.
+	 *
+	 * @param string|object $data        Data
+	 * @param string|null   $primaryKey  Primary key
+	 * @param string        $dateFormat  DateFormat
+	 * @param boolean       $onlyChanged Only Changed Property
+	 *
+	 * @return array
+	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @todo handle primary key outside this
+	 */
+	public static function classToArray(
+		$data,
+		$primaryKey = null,
+		string $dateFormat = 'datetime',
+		bool $onlyChanged = true
+	): array
+	{
+		if (method_exists($data, 'toRawArray'))
+		{
+			$properties = $data->toRawArray($onlyChanged);
+
+			// Always grab the primary key otherwise updates will fail.
+			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties, true)
+				&& ! empty($data->{$primaryKey}))
+			{
+				$properties[$primaryKey] = $data->{$primaryKey};
+			}
+		}
+		else
+		{
+			$mirror = new ReflectionClass($data);
+			$props  = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
+
+			$properties = [];
+
+			// Loop over each property,
+			// saving the name/value in a new array we can return.
+			foreach ($props as $prop)
+			{
+				// Must make protected values accessible.
+				$prop->setAccessible(true);
+				$properties[$prop->getName()] = $prop->getValue($data);
+			}
+		}
+
+		// Convert any Time instances to appropriate $dateFormat
+		if ($properties)
+		{
+			foreach ($properties as $key => $value)
+			{
+				if ($value instanceof Time)
+				{
+					switch ($dateFormat)
+					{
+						case 'datetime':
+							$converted = $value->format('Y-m-d H:i:s');
+							break;
+						case 'date':
+							$converted = $value->format('Y-m-d');
+							break;
+						case 'int':
+							$converted = $value->getTimestamp();
+							break;
+						default:
+							$converted = (string) $value;
+					}
+
+					$properties[$key] = $converted;
+				}
+			}
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Returns last insert ID or 0.
+	 *
+	 * @return integer|string
+	 */
+	public function getInsertID()
+	{
+		return is_numeric($this->insertID) ? (int) $this->insertID : $this->insertID;
+	}
+
+	/**
+	 * Inserts data into the current table. If an object is provided,
+	 * it will attempt to convert it to an array.
+	 *
+	 * @param array|object|null $data     Data
+	 * @param boolean           $returnID Whether insert ID should be returned or not.
+	 *
+	 * @return BaseResult|object|integer|string|false
+	 * @throws ReflectionException ReflectionException.
+	 */
+	public function insert($data = null, bool $returnID = true)
+	{
+		$escape = null;
+
+		$this->insertID = 0;
+
+		if (empty($data))
+		{
+			$data           = $this->tempData['data'] ?? null;
+			$escape         = $this->tempData['escape'] ?? null;
+			$this->tempData = [];
+		}
+
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset('insert');
+		}
+
+		// If $data is using a custom class with public or protected
+		// properties representing the table elements, we need to grab
+		// them as an array.
+		if (is_object($data) && ! $data instanceof stdClass)
+		{
+			//@TODO: Handle Primary Key
+			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, false);
+		}
+
+		// If it's still a stdClass, go ahead and convert to
+		// an array so doProtectFields and other model methods
+		// don't have to do special checks.
+		if (is_object($data))
+		{
+			$data = (array) $data;
+		}
+
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset('insert');
+		}
+
+		// Validate data before saving.
+		if (! $this->skipValidation && ! $this->cleanRules()->validate($data))
+		{
+			return false;
+		}
+
+		// Must be called first so we don't
+		// strip out created_at values.
+		$data = $this->doProtectFields($data);
+
+		// Set created_at and updated_at with same time
+		$date = $this->setDate();
+
+		if ($this->useTimestamps && $this->createdField && ! array_key_exists($this->createdField, $data))
+		{
+			$data[$this->createdField] = $date;
+		}
+
+		if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $data))
+		{
+			$data[$this->updatedField] = $date;
+		}
+
+		$eventData = ['data' => $data];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('beforeInsert', $eventData);
+		}
+
+		$result = $this->_insert($eventData['data'], $escape);
+
+		$eventData = [
+			'id'     => $this->insertID,
+			'data'   => $eventData['data'],
+			'result' => $result,
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			// Trigger afterInsert events with the inserted data and new ID
+			$this->trigger('afterInsert', $eventData);
+		}
+
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+
+		// If insertion failed, get out of here
+		if (! $result)
+		{
+			return $result;
+		}
+
+		// otherwise return the insertID, if requested.
+		return $returnID ? $this->insertID : $result;
+	}
+
+	/**
+	 * Inserts data into the current table. If an object is provided,
+	 * it will attempt to convert it to an array.
+	 *
+	 * @param array|object $data   Data
+	 * @param boolean|null $escape Escape
+	 *
+	 * @return object|integer|string|false
+	 */
+	protected abstract function _insert($data, ?bool $escape = null);
+
+	/**
+	 * Compiles batch insert strings and runs the queries, validating each row prior.
+	 *
+	 * @param array|null $set       An associative array of insert values
+	 * @param boolean    $escape    Whether to escape values and identifiers
+	 * @param integer    $batchSize The size of the batch to run
+	 * @param boolean    $testing   True means only number of records is returned, false will execute the query
+	 *
+	 * @return integer|boolean Number of rows inserted or FALSE on failure
+	 * @throws ReflectionException ReflectionException.
+	 */
+	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100, bool $testing = false)
+	{
+		if (is_array($set))
+		{
+			foreach ($set as &$row)
+			{
+				// If $data is using a custom class with public or protected
+				// properties representing the table elements, we need to grab
+				// them as an array.
+				if (is_object($row) && ! $row instanceof stdClass)
+				{
+					//@TODO: Handle Primary Key
+					$row = static::classToArray($row, $this->primaryKey, $this->dateFormat, false);
+				}
+
+				// If it's still a stdClass, go ahead and convert to
+				// an array so doProtectFields and other model methods
+				// don't have to do special checks.
+				if (is_object($row))
+				{
+					$row = (array) $row;
+				}
+
+				// Validate every row..
+				if (! $this->skipValidation && ! $this->cleanRules()->validate($row))
+				{
+					return false;
+				}
+
+				// Must be called first so we don't
+				// strip out created_at values.
+				$row = $this->doProtectFields($row);
+
+				// Set created_at and updated_at with same time
+				$date = $this->setDate();
+
+				if ($this->useTimestamps && $this->createdField && ! array_key_exists($this->createdField, $row))
+				{
+					$row[$this->createdField] = $date;
+				}
+
+				if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $row))
+				{
+					$row[$this->updatedField] = $date;
+				}
+			}
+		}
+
+		return $this->_insertBatch($set, $escape, $batchSize, $testing);
+	}
+
+	/**
+	 * Compiles batch insert strings and runs the queries, validating each row prior.
+	 *
+	 * @param array|null $set       An associative array of insert values
+	 * @param boolean    $escape    Whether to escape values and identifiers
+	 * @param integer    $batchSize The size of the batch to run
+	 * @param boolean    $testing   True means only number of records is returned, false will execute the query
+	 *
+	 * @return integer|boolean Number of rows inserted or FALSE on failure
+	 * @throws ReflectionException ReflectionException.
+	 */
+	protected abstract function _insertBatch(
+		array $set = null,
+		bool $escape = null,
+		int $batchSize = 100,
+		bool $testing = false
+	);
+
+	/**
+	 * Updates a single record in $this->table. If an object is provided,
+	 * it will attempt to convert it into an array.
+	 *
+	 * @param integer|array|string|null $id   ID
+	 * @param array|object|null         $data Data
+	 *
+	 * @return boolean
+	 * @throws ReflectionException ReflectionException.
+	 */
+	public function update($id = null, $data = null): bool
+	{
+		$escape = null;
+
+		if (is_numeric($id) || is_string($id))
+		{
+			$id = [$id];
+		}
+
+		if (empty($data))
+		{
+			$data           = $this->tempData['data'] ?? null;
+			$escape         = $this->tempData['escape'] ?? null;
+			$this->tempData = [];
+		}
+
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset('update');
+		}
+
+		// If $data is using a custom class with public or protected
+		// properties representing the table elements, we need to grab
+		// them as an array.
+		if (is_object($data) && ! $data instanceof stdClass)
+		{
+			//@TODO: handle primary key
+			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
+		}
+
+		// If it's still a stdClass, go ahead and convert to
+		// an array so doProtectFields and other model methods
+		// don't have to do special checks.
+		if (is_object($data))
+		{
+			$data = (array) $data;
+		}
+
+		// If it's still empty here, means $data is no change or is empty object
+		if (empty($data))
+		{
+			throw DataException::forEmptyDataset('update');
+		}
+
+		// Validate data before saving.
+		if (! $this->skipValidation && ! $this->cleanRules(true)->validate($data))
+		{
+			return false;
+		}
+
+		// Must be called first so we don't
+		// strip out updated_at values.
+		$data = $this->doProtectFields($data);
+
+		if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $data))
+		{
+			$data[$this->updatedField] = $this->setDate();
+		}
+
+		$eventData = [
+			'id'   => $id,
+			'data' => $data,
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$eventData = $this->trigger('beforeUpdate', $eventData);
+		}
+
+		$eventData = [
+			'id'     => $id,
+			'data'   => $eventData['data'],
+			'result' => $this->_update($id, $eventData['data']),
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$this->trigger('afterUpdate', $eventData);
+		}
+
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+
+		return $eventData['result'];
+	}
+
+	/**
+	 * Updates a single record in $this->table. If an object is provided,
+	 * it will attempt to convert it into an array.
+	 *
+	 * @param integer|array|string|null $id     ID
+	 * @param array|object|null         $data   Data
+	 * @param boolean|null              $escape Escape
+	 *
+	 * @return boolean
+	 */
+	protected abstract function _update($id = null, $data = null, ?bool $escape = null): bool;
+
+	/**
+	 * Update_Batch
+	 *
+	 * Compiles an update string and runs the query
+	 *
+	 * @param array|null  $set       An associative array of update values
+	 * @param string|null $index     The where key
+	 * @param integer     $batchSize The size of the batch to run
+	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
+	 *
+	 * @return mixed    Number of rows affected or FALSE on failure
+	 * @throws DatabaseException DatabaseException.
+	 * @throws ReflectionException ReflectionException.
+	 */
+	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
+	{
+		if (is_array($set))
+		{
+			foreach ($set as &$row)
+			{
+				// If $data is using a custom class with public or protected
+				// properties representing the table elements, we need to grab
+				// them as an array.
+				if (is_object($row) && ! $row instanceof stdClass)
+				{
+					//@TODO: Handle Primary Key
+					$row = static::classToArray($row, $this->primaryKey, $this->dateFormat);
+				}
+
+				// If it's still a stdClass, go ahead and convert to
+				// an array so doProtectFields and other model methods
+				// don't have to do special checks.
+				if (is_object($row))
+				{
+					$row = (array) $row;
+				}
+
+				// Validate data before saving.
+				if (! $this->skipValidation && ! $this->cleanRules(true)->validate($row))
+				{
+					return false;
+				}
+
+				// Save updateIndex for later
+				$updateIndex = $row[$index] ?? null;
+
+				// Must be called first so we don't
+				// strip out updated_at values.
+				$row = $this->doProtectFields($row);
+
+				// Restore updateIndex value in case it was wiped out
+				if ($updateIndex !== null)
+				{
+					$row[$index] = $updateIndex;
+				}
+
+				if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $row))
+				{
+					$row[$this->updatedField] = $this->setDate();
+				}
+			}
+		}
+
+		return $this->_updateBatch($set, $index, $batchSize, $returnSQL);
+	}
+
+	/**
+	 * Update_Batch
+	 *
+	 * Compiles an update string and runs the query
+	 *
+	 * @param array|null  $set       An associative array of update values
+	 * @param string|null $index     The where key
+	 * @param integer     $batchSize The size of the batch to run
+	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
+	 *
+	 * @return mixed    Number of rows affected or FALSE on failure
+	 * @throws DatabaseException DatabaseException.
+	 * @throws ReflectionException ReflectionException.
+	 */
+	protected abstract function _updateBatch(
+		array $set = null,
+		string $index = null,
+		int $batchSize = 100,
+		bool $returnSQL = false
+	);
+
+	/**
+	 * Deletes a single record from $this->table where $id matches
+	 * the table's primaryKey
+	 *
+	 * @param integer|string|array|null $id    The rows primary key(s)
+	 * @param boolean                   $purge Allows overriding the soft deletes setting.
+	 *
+	 * @return BaseResult|boolean
+	 * @throws DatabaseException DatabaseException.
+	 */
+	public function delete($id = null, bool $purge = false)
+	{
+		if ($id && (is_numeric($id) || is_string($id)))
+		{
+			$id = [$id];
+		}
+
+		$eventData = [
+			'id'    => $id,
+			'purge' => $purge,
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$this->trigger('beforeDelete', $eventData);
+		}
+
+		$eventData = [
+			'id'     => $id,
+			'data'   => null,
+			'purge'  => $purge,
+			'result' => $this->_delete($id, $purge),
+		];
+
+		if ($this->tempAllowCallbacks)
+		{
+			$this->trigger('afterDelete', $eventData);
+		}
+
+		$this->tempAllowCallbacks = $this->allowCallbacks;
+
+		return $eventData['result'];
+	}
+
+	/**
+	 * Deletes a single record from $this->table where $id matches
+	 * the table's primaryKey
+	 *
+	 * @param integer|string|array|null $id    The rows primary key(s)
+	 * @param boolean                   $purge Allows overriding the soft deletes setting.
+	 *
+	 * @return object|boolean
+	 * @throws DatabaseException DatabaseException.
+	 */
+	protected abstract function _delete($id = null, bool $purge = false);
+
+	/**
+	 * Permanently deletes all rows that have been marked as deleted
+	 * through soft deletes (deleted = 1)
+	 *
+	 * @return boolean|mixed
+	 */
+	public function purgeDeleted()
+	{
+		if (! $this->useSoftDeletes)
+		{
+			return true;
+		}
+
+		return $this->_purgeDeleted();
+	}
+
+	/**
+	 * Permanently deletes all rows that have been marked as deleted
+	 * through soft deletes (deleted = 1)
+	 *
+	 * @return boolean|mixed
+	 */
+	protected abstract function _purgeDeleted();
+
+	/**
+	 * Sets $useSoftDeletes value so that we can temporarily override
+	 * the softdeletes settings. Can be used for all find* methods.
+	 *
+	 * @param boolean $val Value
+	 *
+	 * @return $this
+	 */
+	public function withDeleted(bool $val = true)
+	{
+		$this->tempUseSoftDeletes = ! $val;
+
+		return $this;
+	}
+
+	/**
+	 * Works with the find* methods to return only the rows that
+	 * have been deleted.
+	 *
+	 * @return $this
+	 */
+	public function onlyDeleted()
+	{
+		$this->tempUseSoftDeletes = false;
+		$this->_onlyDeleted();
+
+		return $this;
+	}
+
+	/**
+	 * Works with the find* methods to return only the rows that
+	 * have been deleted.
+	 *
+	 * @return void
+	 */
+	protected abstract function _onlyDeleted();
+
+	/**
+	 * Replace
+	 *
+	 * Compiles a replace into string and runs the query
+	 *
+	 * @param array|null $data      Data
+	 * @param boolean    $returnSQL Set to true to return Query String
+	 *
+	 * @return mixed
+	 */
+	public function replace(array $data = null, bool $returnSQL = false)
+	{
+		// Validate data before saving.
+		if ($data && ! $this->skipValidation && ! $this->cleanRules(true)->validate($data))
+		{
+			return false;
+		}
+
+		return $this->_replace($data, $returnSQL);
+	}
+
+	/**
+	 * Replace
+	 *
+	 * Compiles a replace into string and runs the query
+	 *
+	 * @param array|null $data      Data
+	 * @param boolean    $returnSQL Set to true to return Query String
+	 *
+	 * @return mixed
+	 */
+	protected abstract function _replace(array $data = null, bool $returnSQL = false);
+
+	//--------------------------------------------------------------------
+	// Utility
+	//--------------------------------------------------------------------
+
+	/**
+	 * Sets the return type of the results to be as an associative array.
+	 *
+	 * @return $this
+	 */
+	public function asArray()
+	{
+		$this->tempReturnType = 'array';
+
+		return $this;
+	}
+
+	/**
+	 * Sets the return type to be of the specified type of object.
+	 * Defaults to a simple object, but can be any class that has
+	 * class vars with the same name as the table columns, or at least
+	 * allows them to be created.
+	 *
+	 * @param string $class Class Name
+	 *
+	 * @return $this
+	 */
+	public function asObject(string $class = 'object')
+	{
+		$this->tempReturnType = $class;
+
+		return $this;
+	}
+
+	/**
+	 * Loops over records in batches, allowing you to operate on them.
+	 * Works with $this->builder to get the Compiled select to
+	 * determine the rows to operate on.
+	 *
+	 * @param integer $size     Size
+	 * @param Closure $userFunc Callback Function
+	 *
+	 * @throws DataException DataException.
+	 *
+	 * @return void
+	 */
+	public abstract function chunk(int $size, Closure $userFunc);
+
+	/**
+	 * Works with $this->builder to get the Compiled Select to operate on.
+	 * Expects a GET variable (?page=2) that specifies the page of results
+	 * to display.
+	 *
+	 * @param integer|null $perPage Items per page
+	 * @param string       $group   Will be used by the pagination library to identify a unique pagination set.
+	 * @param integer|null $page    Optional page number (useful when the page number is provided in different way)
+	 * @param integer      $segment Optional URI segment number (if page number is provided by URI segment)
+	 *
+	 * @return array|null
+	 */
+	public function paginate(int $perPage = null, string $group = 'default', int $page = null, int $segment = 0)
+	{
+		$pager = Services::pager(null, null, false);
+
+		if ($segment)
+		{
+			$pager->setSegment($segment);
+		}
+
+		$page = $page >= 1 ? $page : $pager->getCurrentPage($group);
+		// Store it in the Pager libraryو so it can be paginated in the views.
+		$this->pager = $pager->store($group, $page, $perPage, $this->countAllResults(false), $segment);
+		$perPage     = $this->pager->getPerPage($group);
+		$offset      = ($page - 1) * $perPage;
+
+		return $this->findAll($perPage, $offset);
+	}
+
+	/**
+	 * Sets whether or not we should whitelist data set during
+	 * updates or inserts against $this->availableFields.
+	 *
+	 * @param boolean $protect Value
+	 *
+	 * @return $this
+	 */
+	public function protect(bool $protect = true)
+	{
+		$this->protectFields = $protect;
+
+		return $this;
+	}
+
+	/**
+	 * Ensures that only the fields that are allowed to be updated
+	 * are in the data array.
+	 *
+	 * Used by insert() and update() to protect against mass assignment
+	 * vulnerabilities.
+	 *
+	 * @param array $data Data
+	 *
+	 * @return array
+	 * @throws DataException DataException.
+	 */
+	protected function doProtectFields(array $data): array
+	{
+		if (! $this->protectFields)
+		{
+			return $data;
+		}
+
+		if (empty($this->allowedFields))
+		{
+			throw DataException::forInvalidAllowedFields(get_class($this));
+		}
+
+		foreach ($data as $key => $val)
+		{
+			if (! in_array($key, $this->allowedFields, true))
+			{
+				unset($data[$key]);
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * A utility function to allow child models to use the type of
+	 * date/time format that they prefer. This is primarily used for
+	 * setting created_at, updated_at and deleted_at values, but can be
+	 * used by inheriting classes.
+	 *
+	 * The available time formats are:
+	 *  - 'int'      - Stores the date as an integer timestamp
+	 *  - 'datetime' - Stores the data in the SQL datetime format
+	 *  - 'date'     - Stores the date (only) in the SQL date format.
+	 *
+	 * @param integer|null $userData An optional PHP timestamp to be converted.
+	 *
+	 * @return mixed
+	 * @throws ModelException ModelException.
+	 */
+	protected function setDate(?int $userData = null)
+	{
+		$currentDate = $userData ?? time();
+
+		switch ($this->dateFormat)
+		{
+			case 'int':
+				return $currentDate;
+			case 'datetime':
+				return date('Y-m-d H:i:s', $currentDate);
+			case 'date':
+				return date('Y-m-d', $currentDate);
+			default:
+				throw ModelException::forNoDateFormat(static::class);
+		}
+	}
+
+	/**
+	 * Specify the table associated with a model
+	 *
+	 * @param string $table Table
+	 *
+	 * @return $this
+	 */
+	public function setTable(string $table)
+	{
+		$this->table = $table;
+
+		return $this;
+	}
+
+	/**
+	 * Grabs the last error(s) that occurred. If data was validated,
+	 * it will first check for errors there, otherwise will try to
+	 * grab the last error from the Database connection.
+	 *
+	 * @param boolean $forceDB Always grab the db error, not validation
+	 *
+	 * @return array|null
+	 */
+	public function errors(bool $forceDB = false)
+	{
+		// Do we have validation errors?
+		if (! $forceDB && ! $this->skipValidation)
+		{
+			$errors = $this->validation->getErrors();
+
+			if (! empty($errors))
+			{
+				return $errors;
+			}
+		}
+
+		$error = $this->_errors();
+
+		return $error['message'] ?? null;
+	}
+
+	/**
+	 * Grabs the last error(s) that occurred from the Database connection.
+	 *
+	 * @return array|null
+	 */
+	protected abstract function _errors();
+
+	/**
+	 * It could be used when you have to change default or override current allowed fields.
+	 *
+	 * @param array $allowedFields Array with names of fields
+	 *
+	 * @return $this
+	 */
+	public function setAllowedFields(array $allowedFields)
+	{
+		$this->allowedFields = $allowedFields;
+
+		return $this;
+	}
+
+	//--------------------------------------------------------------------
+	// Validation
+	//--------------------------------------------------------------------
+
+	/**
+	 * Set the value of the skipValidation flag.
+	 *
+	 * @param boolean $skip Value
+	 *
+	 * @return $this
+	 */
+	public function skipValidation(bool $skip = true)
+	{
+		$this->skipValidation = $skip;
+
+		return $this;
+	}
+
+	/**
+	 * Allows to set validation messages.
+	 * It could be used when you have to change default or override current validate messages.
+	 *
+	 * @param array $validationMessages Value
+	 *
+	 * @return $this
+	 */
+	public function setValidationMessages(array $validationMessages)
+	{
+		$this->validationMessages = $validationMessages;
+
+		return $this;
+	}
+
+	/**
+	 * Allows to set field wise validation message.
+	 * It could be used when you have to change default or override current validate messages.
+	 *
+	 * @param string $field         Field Name
+	 * @param array  $fieldMessages Validation messages
+	 *
+	 * @return $this
+	 */
+	public function setValidationMessage(string $field, array $fieldMessages)
+	{
+		$this->validationMessages[$field] = $fieldMessages;
+
+		return $this;
+	}
+
+	/**
+	 * Allows to set validation rules.
+	 * It could be used when you have to change default or override current validate rules.
+	 *
+	 * @param array $validationRules Value
+	 *
+	 * @return $this
+	 */
+	public function setValidationRules(array $validationRules)
+	{
+		$this->validationRules = $validationRules;
+
+		return $this;
+	}
+
+	/**
+	 * Allows to set field wise validation rules.
+	 * It could be used when you have to change default or override current validate rules.
+	 *
+	 * @param string       $field      Field Name
+	 * @param string|array $fieldRules Validation rules
+	 *
+	 * @return $this
+	 */
+	public function setValidationRule(string $field, $fieldRules)
+	{
+		$this->validationRules[$field] = $fieldRules;
+
+		return $this;
+	}
+
+	/**
+	 * Should validation rules be removed before saving?
+	 * Most handy when doing updates.
+	 *
+	 * @param boolean $choice Value
+	 *
+	 * @return $this
+	 */
+	public function cleanRules(bool $choice = false)
+	{
+		$this->cleanValidationRules = $choice;
+
+		return $this;
+	}
+
+	/**
+	 * Validate the data against the validation rules (or the validation group)
+	 * specified in the class property, $validationRules.
+	 *
+	 * @param array|object $data Data
+	 *
+	 * @return boolean
+	 */
+	public function validate($data): bool
+	{
+		$rules = $this->getValidationRules();
+
+		if ($this->skipValidation || empty($rules) || empty($data))
+		{
+			return true;
+		}
+
+		// Query Builder works with objects as well as arrays,
+		// but validation requires array, so cast away.
+		if (is_object($data))
+		{
+			$data = (array) $data;
+		}
+
+		$rules = $this->cleanValidationRules ? $this->cleanValidationRules($rules, $data) : $rules;
+
+		// If no data existed that needs validation
+		// our job is done here.
+		if (empty($rules))
+		{
+			return true;
+		}
+
+		return $this->validation->setRules($rules, $this->validationMessages)->run($data, null, $this->DBGroup);
+	}
+
+	/**
+	 * Removes any rules that apply to fields that have not been set
+	 * currently so that rules don't block updating when only updating
+	 * a partial row.
+	 *
+	 * @param array      $rules Array containing field name and rule
+	 * @param array|null $data  Data
+	 *
+	 * @return array
+	 */
+	protected function cleanValidationRules(array $rules, array $data = null): array
+	{
+		if (empty($data))
+		{
+			return [];
+		}
+
+		foreach ($rules as $field => $rule)
+		{
+			if (! array_key_exists($field, $data))
+			{
+				unset($rules[$field]);
+			}
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Replace any placeholders within the rules with the values that
+	 * match the 'key' of any properties being set. For example, if
+	 * we had the following $data array:
+	 *
+	 * [ 'id' => 13 ]
+	 *
+	 * and the following rule:
+	 *
+	 *  'required|is_unique[users,email,id,{id}]'
+	 *
+	 * The value of {id} would be replaced with the actual id in the form data:
+	 *
+	 *  'required|is_unique[users,email,id,13]'
+	 *
+	 * @param array $rules Validation rules
+	 * @param array $data  Data
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @deprecated use fillPlaceholders($rules, $data) from Validation instead
+	 *
+	 * @return array
+	 */
+	protected function fillPlaceholders(array $rules, array $data): array
+	{
+		$replacements = [];
+
+		foreach ($data as $key => $value)
+		{
+			$replacements["{{$key}}"] = $value;
+		}
+
+		if (! empty($replacements))
+		{
+			foreach ($rules as &$rule)
+			{
+				if (is_array($rule))
+				{
+					foreach ($rule as &$row)
+					{
+						// Should only be an `errors` array
+						// which doesn't take placeholders.
+						if (is_array($row))
+						{
+							continue;
+						}
+
+						$row = strtr($row, $replacements);
+					}
+
+					continue;
+				}
+
+				$rule = strtr($rule, $replacements);
+			}
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Returns the model's defined validation rules so that they
+	 * can be used elsewhere, if needed.
+	 *
+	 * @param array $options Options
+	 *
+	 * @return array
+	 */
+	public function getValidationRules(array $options = []): array
+	{
+		$rules = $this->validationRules;
+
+		// ValidationRules can be either a string, which is the group name,
+		// or an array of rules.
+		if (is_string($rules))
+		{
+			$rules = $this->validation->loadRuleGroup($rules); // @phpstan-ignore-line
+		}
+
+		if (isset($options['except']))
+		{
+			$rules = array_diff_key($rules, array_flip($options['except']));
+		}
+		elseif (isset($options['only']))
+		{
+			$rules = array_intersect_key($rules, array_flip($options['only']));
+		}
+
+		return $rules;
+	}
+
+	/**
+	 * Returns the model's define validation messages so they
+	 * can be used elsewhere, if needed.
+	 *
+	 * @return array
+	 */
+	public function getValidationMessages(): array
+	{
+		return $this->validationMessages;
+	}
+
+	/**
+	 * Override countAllResults to account for soft deleted accounts.
+	 *
+	 * @param boolean $reset Reset
+	 * @param boolean $test  Test
+	 *
+	 * @return mixed
+	 */
+	public abstract function countAllResults(bool $reset = true, bool $test = false);
+
+	/**
+	 * Sets $tempAllowCallbacks value so that we can temporarily override
+	 * the setting. Resets after the next method that uses triggers.
+	 *
+	 * @param boolean $val
+	 *
+	 * @return $this
+	 */
+	public function allowCallbacks(bool $val = true)
+	{
+		$this->tempAllowCallbacks = $val;
+
+		return $this;
+	}
+
+	/**
+	 * A simple event trigger for Model Events that allows additional
+	 * data manipulation within the model. Specifically intended for
+	 * usage by child models this can be used to format data,
+	 * save/load related classes, etc.
+	 *
+	 * It is the responsibility of the callback methods to return
+	 * the data itself.
+	 *
+	 * Each $eventData array MUST have a 'data' key with the relevant
+	 * data for callback methods (like an array of key/value pairs to insert
+	 * or update, an array of results, etc)
+	 *
+	 * If callbacks are not allowed then returns $eventData immediately.
+	 *
+	 * @param string $event     Event
+	 * @param array  $eventData Event Data
+	 *
+	 * @return mixed
+	 * @throws DataException DataException.
+	 */
+	protected function trigger(string $event, array $eventData)
+	{
+		// Ensure it's a valid event
+		if (! isset($this->{$event}) || empty($this->{$event}))
+		{
+			return $eventData;
+		}
+
+		foreach ($this->{$event} as $callback)
+		{
+			if (! method_exists($this, $callback))
+			{
+				throw DataException::forInvalidMethodTriggered($callback);
+			}
+
+			$eventData = $this->{$callback}($eventData);
+		}
+
+		return $eventData;
+	}
+
+	//--------------------------------------------------------------------
+	// Magic
+	//--------------------------------------------------------------------
+
+	/**
+	 * Provides/instantiates the builder/db connection and model's table/primary key names and return type.
+	 *
+	 * @param string $name Name
+	 *
+	 * @return mixed
+	 */
+	public function __get(string $name)
+	{
+		if (property_exists($this, $name))
+		{
+			return $this->$name;
+		}
+
+		if (isset($this->db->$name))
+		{
+			return $this->db->$name;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Checks for the existence of properties across this model, builder, and db connection.
+	 *
+	 * @param string $name Name
+	 *
+	 * @return boolean
+	 */
+	public function __isset(string $name): bool
+	{
+		if (property_exists($this, $name))
+		{
+			return true;
+		}
+
+		if (isset($this->db->$name))
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Provides direct access to method in the builder (if available)
+	 * and the database connection.
+	 *
+	 * @param string $name   Name
+	 * @param array  $params Params
+	 *
+	 * @return $this|null
+	 */
+	public function __call(string $name, array $params)
+	{
+		$result = null;
+
+		if (method_exists($this->db, $name))
+		{
+			$result = $this->db->{$name}(...$params);
+		}
+
+		return $result;
+	}
+}

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -28,23 +28,22 @@ use stdClass;
 /**
  * Class Model
  *
- * The BaseModel class provides a number of convenient features that
- * makes working with a databases less painful. Extending this class
- * provide means of implementing various database systems
+ * The BaseModel class provides a number of features that makes
+ * working with databases more convenient. The properties and
+ * methods in this class are those common to all supported
+ * database systems.
  *
- * It will:
+ * Overview:
  *      - simplifies pagination
- *      - allow specifying the return type (array, object, etc) with each call
- *      - automatically set and update timestamps
- *      - handle soft deletes
- *      - ensure validation is run against objects when saving items
- *      - process various callbacks
- *      - allow intermingling calls to the db connection
+ *      - allows specifying the return type (array, object, etc) with each call
+ *      - automatically sets and updates timestamps
+ *      - handles soft deletes
+ *      - ensures validation against objects when saving items
+ *      - processes internal event callbacks
+ *      - intermingles calls with the underlying connection
  */
 abstract class BaseModel
 {
-	// region Properties
-
 	/**
 	 * Pager instance.
 	 * Populated after calling $this->paginate()
@@ -287,10 +286,6 @@ abstract class BaseModel
 	 */
 	protected $afterDelete = [];
 
-	// endregion
-
-	// region Constructor
-
 	/**
 	 * BaseModel constructor.
 	 *
@@ -303,10 +298,6 @@ abstract class BaseModel
 		$this->tempAllowCallbacks = $this->allowCallbacks;
 		$this->validation         = $validation ?? Services::validation(null, false);
 	}
-
-	// endregion
-
-	// region Abstract Methods
 
 	/**
 	 * Fetches the row of database
@@ -484,10 +475,6 @@ abstract class BaseModel
 	 */
 	abstract public function chunk(int $size, Closure $userFunc);
 
-	// endregion
-
-	// region CRUD & Finders
-
 	/**
 	 * Fetches the row of database
 	 *
@@ -549,7 +536,7 @@ abstract class BaseModel
 			throw DataException::forFindColumnHaveMultipleColumns();
 		}
 
-		$resultSet = $resultSet = $this->doFindColumn($columnName);
+		$resultSet = $this->doFindColumn($columnName);
 
 		return $resultSet ? array_column($resultSet, $columnName) : null;
 	}
@@ -1148,10 +1135,6 @@ abstract class BaseModel
 		return $error['message'] ?? null;
 	}
 
-	// endregion
-
-	// region Pager
-
 	/**
 	 * Works with Pager to get the size and offset parameters.
 	 * Expects a GET variable (?page=2) that specifies the page of results
@@ -1181,10 +1164,6 @@ abstract class BaseModel
 
 		return $this->findAll($perPage, $offset);
 	}
-
-	// endregion
-
-	// region Allowed Fields
 
 	/**
 	 * It could be used when you have to change default or override current allowed fields.
@@ -1250,10 +1229,6 @@ abstract class BaseModel
 
 		return $data;
 	}
-
-	// endregion
-
-	// region Timestamps
 
 	/**
 	 * Sets the date or current date if null value is passed
@@ -1328,10 +1303,6 @@ abstract class BaseModel
 				return (string) $value;
 		}
 	}
-
-	// endregion
-
-	// region Validation
 
 	/**
 	 * Set the value of the skipValidation flag.
@@ -1530,10 +1501,6 @@ abstract class BaseModel
 		return $rules;
 	}
 
-	// endregion
-
-	// region Callbacks
-
 	/**
 	 * Sets $tempAllowCallbacks value so that we can temporarily override
 	 * the setting. Resets after the next method that uses triggers.
@@ -1591,10 +1558,6 @@ abstract class BaseModel
 
 		return $eventData;
 	}
-
-	// endregion
-
-	// region Utility
 
 	/**
 	 * Sets the return type of the results to be as an associative array.
@@ -1703,10 +1666,6 @@ abstract class BaseModel
 		return $properties;
 	}
 
-	// endregion
-
-	// region Magic
-
 	/**
 	 * Provides the db connection and model's properties.
 	 *
@@ -1771,10 +1730,6 @@ abstract class BaseModel
 		return $result;
 	}
 
-	// endregion
-
-	// region Deprecated
-
 	/**
 	 * Replace any placeholders within the rules with the values that
 	 * match the 'key' of any properties being set. For example, if
@@ -1835,6 +1790,4 @@ abstract class BaseModel
 
 		return $rules;
 	}
-
-	// endregion
 }

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -158,8 +158,6 @@ abstract class BaseModel
 	 * Database Connection
 	 *
 	 * @var object
-	 *
-	 * @todo check if ConnectionInterface can be used for NO-SQL
 	 */
 	protected $db;
 
@@ -365,8 +363,9 @@ abstract class BaseModel
 	 *
 	 * @param string $columnName Column Name
 	 *
-	 * @return array|null   The resulting row of data, or null if no data found.
-	 * @throws DataException Data Exception.
+	 * @return array|null The resulting row of data, or null if no data found.
+	 *
+	 * @throws DataException
 	 */
 	public function findColumn(string $columnName)
 	{
@@ -386,8 +385,9 @@ abstract class BaseModel
 	 *
 	 * @param string $columnName Column Name
 	 *
-	 * @return array|null   The resulting row of data, or null if no data found.
-	 * @throws DataException Data Exception.
+	 * @return array|null The resulting row of data, or null if no data found.
+	 *
+	 * @throws DataException
 	 */
 	abstract protected function doFindColumn(string $columnName);
 
@@ -543,7 +543,8 @@ abstract class BaseModel
 	 * @param boolean       $recursive   If true, inner entities will be casted as array as well
 	 *
 	 * @return array Array
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	protected function objectToArray($data, bool $onlyChanged = true, bool $recursive = false): array
 	{
@@ -583,7 +584,8 @@ abstract class BaseModel
 	 * @param boolean       $recursive   If true, inner entities will be casted as array as well
 	 *
 	 * @return array|null Array
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
 	{
@@ -637,7 +639,8 @@ abstract class BaseModel
 	 * @param boolean|null      $escape   Escape
 	 *
 	 * @return BaseResult|object|integer|string|false
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	public function insert($data = null, bool $returnID = true, ?bool $escape = null)
 	{
@@ -734,18 +737,19 @@ abstract class BaseModel
 	 *
 	 * @return object|integer|string|false
 	 */
-	abstract protected function doInsert($data, ?bool $escape = null);
+	abstract protected function doInsert(array $data, ?bool $escape = null);
 
 	/**
 	 * Compiles batch insert runs the queries, validating each row prior.
 	 *
-	 * @param array|null   $set       An associative array of insert values
+	 * @param array|null   $set       an associative array of insert values
 	 * @param boolean|null $escape    Whether to escape values and identifiers
 	 * @param integer      $batchSize The size of the batch to run
 	 * @param boolean      $testing   True means only number of records is returned, false will execute the query
 	 *
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	public function insertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false)
 	{
@@ -807,14 +811,8 @@ abstract class BaseModel
 	 * @param boolean      $testing   True means only number of records is returned, false will execute the query
 	 *
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
-	 * @throws ReflectionException ReflectionException.
 	 */
-	abstract protected function doInsertBatch(
-		?array $set = null,
-		?bool $escape = null,
-		int $batchSize = 100,
-		bool $testing = false
-	);
+	abstract protected function doInsertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false);
 
 	/**
 	 * Updates a single record in the database. If an object is provided,
@@ -825,7 +823,8 @@ abstract class BaseModel
 	 * @param boolean|null              $escape Escape
 	 *
 	 * @return boolean
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	public function update($id = null, $data = null, ?bool $escape = null): bool
 	{
@@ -923,8 +922,9 @@ abstract class BaseModel
 	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
 	 *
 	 * @return mixed    Number of rows affected or FALSE on failure
-	 * @throws DatabaseException DatabaseException.
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws DatabaseException
+	 * @throws ReflectionException
 	 */
 	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
 	{
@@ -987,15 +987,10 @@ abstract class BaseModel
 	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
 	 *
 	 * @return mixed    Number of rows affected or FALSE on failure
-	 * @throws DatabaseException DatabaseException.
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws DatabaseException
 	 */
-	abstract protected function doUpdateBatch(
-		array $set = null,
-		string $index = null,
-		int $batchSize = 100,
-		bool $returnSQL = false
-	);
+	abstract protected function doUpdateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false);
 
 	/**
 	 * Deletes a single record from the database where $id matches
@@ -1004,7 +999,8 @@ abstract class BaseModel
 	 * @param boolean                   $purge Allows overriding the soft deletes setting.
 	 *
 	 * @return BaseResult|boolean
-	 * @throws DatabaseException DatabaseException.
+	 *
+	 * @throws DatabaseException
 	 */
 	public function delete($id = null, bool $purge = false)
 	{
@@ -1048,7 +1044,8 @@ abstract class BaseModel
 	 * @param boolean                   $purge Allows overriding the soft deletes setting.
 	 *
 	 * @return object|boolean
-	 * @throws DatabaseException DatabaseException.
+	 *
+	 * @throws DatabaseException
 	 */
 	abstract protected function doDelete($id = null, bool $purge = false);
 
@@ -1185,9 +1182,9 @@ abstract class BaseModel
 	 * @param integer $size     Size
 	 * @param Closure $userFunc Callback Function
 	 *
-	 * @throws DataException DataException.
-	 *
 	 * @return void
+	 *
+	 * @throws DataException
 	 */
 	public abstract function chunk(int $size, Closure $userFunc);
 
@@ -1246,7 +1243,8 @@ abstract class BaseModel
 	 * @param array $data Data
 	 *
 	 * @return array
-	 * @throws DataException DataException.
+	 *
+	 * @throws DataException
 	 */
 	protected function doProtectFields(array $data): array
 	{
@@ -1285,7 +1283,8 @@ abstract class BaseModel
 	 * @param integer|null $userData An optional PHP timestamp to be converted.
 	 *
 	 * @return mixed
-	 * @throws ModelException ModelException.
+	 *
+	 * @throws ModelException
 	 */
 	protected function setDate(?int $userData = null)
 	{
@@ -1541,7 +1540,7 @@ abstract class BaseModel
 
 		foreach ($data as $key => $value)
 		{
-			$replacements["{{$key}}"] = $value;
+			$replacements['{' . $key . '}'] = $value;
 		}
 
 		if (! empty($replacements))
@@ -1588,7 +1587,8 @@ abstract class BaseModel
 		// or an array of rules.
 		if (is_string($rules))
 		{
-			$rules = $this->validation->loadRuleGroup($rules); // @phpstan-ignore-line
+			// @phpstan-ignore-next-line
+			$rules = $this->validation->loadRuleGroup($rules);
 		}
 
 		if (isset($options['except']))
@@ -1629,7 +1629,7 @@ abstract class BaseModel
 	 * Sets $tempAllowCallbacks value so that we can temporarily override
 	 * the setting. Resets after the next method that uses triggers.
 	 *
-	 * @param boolean $val
+	 * @param boolean $val value
 	 *
 	 * @return $this
 	 */
@@ -1659,7 +1659,8 @@ abstract class BaseModel
 	 * @param array  $eventData Event Data
 	 *
 	 * @return mixed
-	 * @throws DataException DataException.
+	 *
+	 * @throws DataException
 	 */
 	protected function trigger(string $event, array $eventData)
 	{

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -289,7 +289,7 @@ abstract class BaseModel
 
 	/**
 	 * Holds information passed in via 'set'
-	 * so that we can capture it (not the builder)
+	 * so that we can capture it
 	 * and ensure it gets validated first.
 	 *
 	 * @var array
@@ -664,7 +664,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Inserts data into the current table. If an object is provided,
+	 * Inserts data into the database. If an object is provided,
 	 * it will attempt to convert it to an array.
 	 *
 	 * @param array|object|null $data     Data
@@ -692,7 +692,7 @@ abstract class BaseModel
 		}
 
 		// If $data is using a custom class with public or protected
-		// properties representing the table elements, we need to grab
+		// properties representing the collection elements, we need to grab
 		// them as an array.
 		if (is_object($data) && ! $data instanceof stdClass)
 		{
@@ -769,11 +769,10 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Inserts data into the current table. If an object is provided,
-	 * it will attempt to convert it to an array.
+	 * Inserts data into the current database
 	 * This methods works only with dbCalls
 	 *
-	 * @param array|object $data   Data
+	 * @param array        $data   Data
 	 * @param boolean|null $escape Escape
 	 *
 	 * @return object|integer|string|false
@@ -798,7 +797,7 @@ abstract class BaseModel
 			foreach ($set as &$row)
 			{
 				// If $data is using a custom class with public or protected
-				// properties representing the table elements, we need to grab
+				// properties representing the collection elements, we need to grab
 				// them as an array.
 				if (is_object($row) && ! $row instanceof stdClass)
 				{
@@ -892,7 +891,7 @@ abstract class BaseModel
 		}
 
 		// If $data is using a custom class with public or protected
-		// properties representing the table elements, we need to grab
+		// properties representing the collection elements, we need to grab
 		// them as an array.
 		if (is_object($data) && ! $data instanceof stdClass)
 		{
@@ -985,7 +984,7 @@ abstract class BaseModel
 			foreach ($set as &$row)
 			{
 				// If $data is using a custom class with public or protected
-				// properties representing the table elements, we need to grab
+				// properties representing the collection elements, we need to grab
 				// them as an array.
 				if (is_object($row) && ! $row instanceof stdClass)
 				{
@@ -1216,8 +1215,8 @@ abstract class BaseModel
 	/**
 	 * Sets the return type to be of the specified type of object.
 	 * Defaults to a simple object, but can be any class that has
-	 * class vars with the same name as the table columns, or at least
-	 * allows them to be created.
+	 * class vars with the same name as the collection columns,
+	 * or at least allows them to be created.
 	 *
 	 * @param string $class Class Name
 	 *
@@ -1517,8 +1516,7 @@ abstract class BaseModel
 			return true;
 		}
 
-		// Query Builder works with objects as well as arrays,
-		// but validation requires array, so cast away.
+		//Validation requires array, so cast away.
 		if (is_object($data))
 		{
 			$data = (array) $data;
@@ -1740,7 +1738,7 @@ abstract class BaseModel
 	//--------------------------------------------------------------------
 
 	/**
-	 * Provides/instantiates the builder/db connection and model's table/primary key names and return type.
+	 * Provides the db connection and model's properties.
 	 *
 	 * @param string $name Name
 	 *
@@ -1762,7 +1760,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Checks for the existence of properties across this model, builder, and db connection.
+	 * Checks for the existence of properties across this model, and db connection.
 	 *
 	 * @param string $name Name
 	 *
@@ -1784,8 +1782,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Provides direct access to method in the builder (if available)
-	 * and the database connection.
+	 * Provides direct access to method in the database connection.
 	 *
 	 * @param string $name   Name
 	 * @param array  $params Params

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -297,7 +297,7 @@ abstract class BaseModel
 	protected $tempData = [];
 
 	/**
-	 * Model constructor.
+	 * BaseModel constructor.
 	 *
 	 * @param object|null              $db         DB Connection
 	 * @param ValidationInterface|null $validation Validation
@@ -317,12 +317,11 @@ abstract class BaseModel
 	//--------------------------------------------------------------------
 
 	/**
-	 * Fetches the row of database from $this->table with a primary key
-	 * matching $id.
+	 * Fetches the row of database
 	 *
 	 * @param array|integer|string|null $id One primary key or an array of primary keys
 	 *
-	 * @return array|object|null    The resulting row of data, or null.
+	 * @return array|object|null The resulting row of data, or null.
 	 */
 	public function find($id = null)
 	{
@@ -363,19 +362,18 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Fetches the row of database from $this->table with a primary key
-	 * matching $id. This methods works only with dbCalls
+	 * Fetches the row of database
 	 * This methods works only with dbCalls
 	 *
 	 * @param boolean                   $singleton Single or multiple results
 	 * @param array|integer|string|null $id        One primary key or an array of primary keys
 	 *
-	 * @return array|object|null    The resulting row of data, or null.
+	 * @return array|object|null The resulting row of data, or null.
 	 */
 	abstract protected function doFind(bool $singleton, $id = null);
 
 	/**
-	 * Fetches the column of database from $this->table
+	 * Fetches the column of database
 	 *
 	 * @param string $columnName Column Name
 	 *
@@ -395,7 +393,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Fetches the column of database from $this->table
+	 * Fetches the column of database
 	 * This methods works only with dbCalls
 	 *
 	 * @param string $columnName Column Name
@@ -406,8 +404,7 @@ abstract class BaseModel
 	abstract protected function doFindColumn(string $columnName);
 
 	/**
-	 * Works with the current Query Builder instance to return
-	 * all results, while optionally limiting them.
+	 * Fetches all results, while optionally limiting them.
 	 *
 	 * @param integer $limit  Limit
 	 * @param integer $offset Offset
@@ -453,8 +450,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Works with the current Query Builder instance to return
-	 * all results, while optionally limiting them.
+	 * Fetches all results, while optionally limiting them.
 	 * This methods works only with dbCalls
 	 *
 	 * @param integer $limit  Limit
@@ -465,8 +461,7 @@ abstract class BaseModel
 	abstract protected function doFindAll(int $limit = 0, int $offset = 0);
 
 	/**
-	 * Returns the first row of the result set. Will take any previous
-	 * Query Builder calls into account when determining the result set.
+	 * Returns the first row of the result set.
 	 *
 	 * @return array|object|null
 	 */
@@ -505,8 +500,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Returns the first row of the result set. Will take any previous
-	 * Query Builder calls into account when determining the result set.
+	 * Returns the first row of the result set.
 	 * This methods works only with dbCalls
 	 *
 	 * @return array|object|null
@@ -523,6 +517,8 @@ abstract class BaseModel
 	 * @param boolean     $escape Whether to escape values and identifiers
 	 *
 	 * @return $this
+	 *
+	 * @todo check if should be moved to Model
 	 */
 	public function set($key, ?string $value = '', bool $escape = null)
 	{
@@ -566,6 +562,8 @@ abstract class BaseModel
 	 * @param array|object $data Data
 	 *
 	 * @return boolean
+	 *
+	 * @todo: to be reworked
 	 */
 	abstract protected function doSave($data): bool;
 
@@ -783,7 +781,7 @@ abstract class BaseModel
 	abstract protected function doInsert($data, ?bool $escape = null);
 
 	/**
-	 * Compiles batch insert strings and runs the queries, validating each row prior.
+	 * Compiles batch insert runs the queries, validating each row prior.
 	 *
 	 * @param array|null $set       An associative array of insert values
 	 * @param boolean    $escape    Whether to escape values and identifiers
@@ -844,7 +842,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Compiles batch insert strings and runs the queries, validating each row prior.
+	 * Compiles batch insert and runs the queries, validating each row prior.
 	 * This methods works only with dbCalls
 	 *
 	 * @param array|null $set       An associative array of insert values
@@ -863,7 +861,7 @@ abstract class BaseModel
 	);
 
 	/**
-	 * Updates a single record in $this->table. If an object is provided,
+	 * Updates a single record in the database. If an object is provided,
 	 * it will attempt to convert it into an array.
 	 *
 	 * @param integer|array|string|null $id   ID
@@ -957,12 +955,11 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Updates a single record in $this->table. If an object is provided,
-	 * it will attempt to convert it into an array.
+	 * Updates a single record in the database.
 	 * This methods works only with dbCalls
 	 *
 	 * @param integer|array|string|null $id     ID
-	 * @param array|object|null         $data   Data
+	 * @param array|null                $data   Data
 	 * @param boolean|null              $escape Escape
 	 *
 	 * @return boolean
@@ -970,7 +967,7 @@ abstract class BaseModel
 	abstract protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool;
 
 	/**
-	 * Compiles an update string and runs the query
+	 * Compiles an update and runs the query
 	 *
 	 * @param array|null  $set       An associative array of update values
 	 * @param string|null $index     The where key
@@ -1033,7 +1030,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Compiles an update string and runs the query
+	 * Compiles an update and runs the query
 	 * This methods works only with dbCalls
 	 *
 	 * @param array|null  $set       An associative array of update values
@@ -1053,8 +1050,7 @@ abstract class BaseModel
 	);
 
 	/**
-	 * Deletes a single record from $this->table where $id matches
-	 * the table's primaryKey
+	 * Deletes a single record from the database where $id matches
 	 *
 	 * @param integer|string|array|null $id    The rows primary key(s)
 	 * @param boolean                   $purge Allows overriding the soft deletes setting.
@@ -1097,8 +1093,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Deletes a single record from $this->table where $id matches
-	 * the table's primaryKey
+	 * Deletes a single record from the database where $id matches
 	 * This methods works only with dbCalls
 	 *
 	 * @param integer|string|array|null $id    The rows primary key(s)
@@ -1136,7 +1131,7 @@ abstract class BaseModel
 
 	/**
 	 * Sets $useSoftDeletes value so that we can temporarily override
-	 * the softdeletes settings. Can be used for all find* methods.
+	 * the soft deletes settings. Can be used for all find* methods.
 	 *
 	 * @param boolean $val Value
 	 *
@@ -1173,7 +1168,7 @@ abstract class BaseModel
 	abstract protected function doOnlyDeleted();
 
 	/**
-	 * Compiles a replace into string and runs the query
+	 * Compiles a replace and runs the query
 	 *
 	 * @param array|null $data      Data
 	 * @param boolean    $returnSQL Set to true to return Query String
@@ -1192,7 +1187,7 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Compiles a replace into string and runs the query
+	 * Compiles a replace and runs the query
 	 * This methods works only with dbCalls
 	 *
 	 * @param array|null $data      Data
@@ -1237,8 +1232,6 @@ abstract class BaseModel
 
 	/**
 	 * Loops over records in batches, allowing you to operate on them.
-	 * Works with $this->builder to get the Compiled select to
-	 * determine the rows to operate on.
 	 * This methods works only with dbCalls
 	 *
 	 * @param integer $size     Size
@@ -1251,7 +1244,7 @@ abstract class BaseModel
 	public abstract function chunk(int $size, Closure $userFunc);
 
 	/**
-	 * Works with $this->builder to get the Compiled Select to operate on.
+	 * Works with Pager to get the size and offset parameters.
 	 * Expects a GET variable (?page=2) that specifies the page of results
 	 * to display.
 	 *

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -364,6 +364,7 @@ abstract class BaseModel
 	/**
 	 * Fetches the row of database from $this->table with a primary key
 	 * matching $id. This methods works only with dbCalls
+	 * This methods works only with dbCalls
 	 *
 	 * @param boolean                   $singleton Single or multiple results
 	 * @param array|integer|string|null $id        One primary key or an array of primary keys
@@ -394,6 +395,7 @@ abstract class BaseModel
 
 	/**
 	 * Fetches the column of database from $this->table
+	 * This methods works only with dbCalls
 	 *
 	 * @param string $columnName Column Name
 	 *
@@ -452,6 +454,7 @@ abstract class BaseModel
 	/**
 	 * Works with the current Query Builder instance to return
 	 * all results, while optionally limiting them.
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer $limit  Limit
 	 * @param integer $offset Offset
@@ -503,6 +506,7 @@ abstract class BaseModel
 	/**
 	 * Returns the first row of the result set. Will take any previous
 	 * Query Builder calls into account when determining the result set.
+	 * This methods works only with dbCalls
 	 *
 	 * @return array|object|null
 	 */
@@ -556,6 +560,7 @@ abstract class BaseModel
 	 * an array or object. When using with custom class objects,
 	 * you must ensure that the class will provide access to the class
 	 * variables, even if through a magic method.
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|object $data Data
 	 *
@@ -767,6 +772,7 @@ abstract class BaseModel
 	/**
 	 * Inserts data into the current table. If an object is provided,
 	 * it will attempt to convert it to an array.
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|object $data   Data
 	 * @param boolean|null $escape Escape
@@ -838,6 +844,7 @@ abstract class BaseModel
 
 	/**
 	 * Compiles batch insert strings and runs the queries, validating each row prior.
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|null $set       An associative array of insert values
 	 * @param boolean    $escape    Whether to escape values and identifiers
@@ -951,6 +958,7 @@ abstract class BaseModel
 	/**
 	 * Updates a single record in $this->table. If an object is provided,
 	 * it will attempt to convert it into an array.
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer|array|string|null $id     ID
 	 * @param array|object|null         $data   Data
@@ -961,8 +969,6 @@ abstract class BaseModel
 	abstract protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool;
 
 	/**
-	 * Update_Batch
-	 *
 	 * Compiles an update string and runs the query
 	 *
 	 * @param array|null  $set       An associative array of update values
@@ -1026,9 +1032,8 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Update_Batch
-	 *
 	 * Compiles an update string and runs the query
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|null  $set       An associative array of update values
 	 * @param string|null $index     The where key
@@ -1093,6 +1098,7 @@ abstract class BaseModel
 	/**
 	 * Deletes a single record from $this->table where $id matches
 	 * the table's primaryKey
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer|string|array|null $id    The rows primary key(s)
 	 * @param boolean                   $purge Allows overriding the soft deletes setting.
@@ -1121,6 +1127,7 @@ abstract class BaseModel
 	/**
 	 * Permanently deletes all rows that have been marked as deleted
 	 * through soft deletes (deleted = 1)
+	 * This methods works only with dbCalls
 	 *
 	 * @return boolean|mixed
 	 */
@@ -1158,14 +1165,13 @@ abstract class BaseModel
 	/**
 	 * Works with the find* methods to return only the rows that
 	 * have been deleted.
+	 * This methods works only with dbCalls
 	 *
 	 * @return void
 	 */
 	abstract protected function doOnlyDeleted();
 
 	/**
-	 * Replace
-	 *
 	 * Compiles a replace into string and runs the query
 	 *
 	 * @param array|null $data      Data
@@ -1185,9 +1191,8 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Replace
-	 *
 	 * Compiles a replace into string and runs the query
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|null $data      Data
 	 * @param boolean    $returnSQL Set to true to return Query String
@@ -1233,6 +1238,7 @@ abstract class BaseModel
 	 * Loops over records in batches, allowing you to operate on them.
 	 * Works with $this->builder to get the Compiled select to
 	 * determine the rows to operate on.
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer $size     Size
 	 * @param Closure $userFunc Callback Function
@@ -1385,6 +1391,7 @@ abstract class BaseModel
 
 	/**
 	 * Grabs the last error(s) that occurred from the Database connection.
+	 * This methods works only with dbCalls
 	 *
 	 * @return array|null
 	 */
@@ -1668,13 +1675,14 @@ abstract class BaseModel
 
 	/**
 	 * Override countAllResults to account for soft deleted accounts.
+	 * This methods works only with dbCalls
 	 *
 	 * @param boolean $reset Reset
 	 * @param boolean $test  Test
 	 *
 	 * @return mixed
 	 */
-	public abstract function countAllResults(bool $reset = true, bool $test = false);
+	abstract public function countAllResults(bool $reset = true, bool $test = false);
 
 	/**
 	 * Sets $tempAllowCallbacks value so that we can temporarily override

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -43,6 +43,8 @@ use stdClass;
  */
 abstract class BaseModel
 {
+	// region Properties
+
 	/**
 	 * Pager instance.
 	 * Populated after calling $this->paginate()
@@ -285,6 +287,10 @@ abstract class BaseModel
 	 */
 	protected $afterDelete = [];
 
+	// endregion
+
+	// region Constructor
+
 	/**
 	 * BaseModel constructor.
 	 *
@@ -298,9 +304,196 @@ abstract class BaseModel
 		$this->validation         = $validation ?? Services::validation(null, false);
 	}
 
-	//--------------------------------------------------------------------
-	// CRUD & FINDERS
-	//--------------------------------------------------------------------
+	// endregion
+
+	// region Abstract Methods
+
+	/**
+	 * Fetches the row of database
+	 * This methods works only with dbCalls
+	 *
+	 * @param boolean                   $singleton Single or multiple results
+	 * @param array|integer|string|null $id        One primary key or an array of primary keys
+	 *
+	 * @return array|object|null The resulting row of data, or null.
+	 */
+	abstract protected function doFind(bool $singleton, $id = null);
+
+	/**
+	 * Fetches the column of database
+	 * This methods works only with dbCalls
+	 *
+	 * @param string $columnName Column Name
+	 *
+	 * @return array|null The resulting row of data, or null if no data found.
+	 *
+	 * @throws DataException
+	 */
+	abstract protected function doFindColumn(string $columnName);
+
+	/**
+	 * Fetches all results, while optionally limiting them.
+	 * This methods works only with dbCalls
+	 *
+	 * @param integer $limit  Limit
+	 * @param integer $offset Offset
+	 *
+	 * @return array
+	 */
+	abstract protected function doFindAll(int $limit = 0, int $offset = 0);
+
+	/**
+	 * Returns the first row of the result set.
+	 * This methods works only with dbCalls
+	 *
+	 * @return array|object|null
+	 */
+	abstract protected function doFirst();
+
+	/**
+	 * A convenience method that will attempt to determine whether the
+	 * data should be inserted or updated. Will work with either
+	 * an array or object. When using with custom class objects,
+	 * you must ensure that the class will provide access to the class
+	 * variables, even if through a magic method.
+	 * This methods works only with dbCalls
+	 *
+	 * @param array|object $data Data
+	 *
+	 * @return boolean
+	 *
+	 * @todo: to be reworked
+	 */
+	abstract protected function doSave($data): bool;
+
+	/**
+	 * Inserts data into the current database
+	 * This methods works only with dbCalls
+	 *
+	 * @param array        $data   Data
+	 * @param boolean|null $escape Escape
+	 *
+	 * @return object|integer|string|false
+	 */
+	abstract protected function doInsert(array $data, ?bool $escape = null);
+
+	/**
+	 * Compiles batch insert and runs the queries, validating each row prior.
+	 * This methods works only with dbCalls
+	 *
+	 * @param array|null   $set       An associative array of insert values
+	 * @param boolean|null $escape    Whether to escape values and identifiers
+	 * @param integer      $batchSize The size of the batch to run
+	 * @param boolean      $testing   True means only number of records is returned, false will execute the query
+	 *
+	 * @return integer|boolean Number of rows inserted or FALSE on failure
+	 */
+	abstract protected function doInsertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false);
+
+	/**
+	 * Updates a single record in the database.
+	 * This methods works only with dbCalls
+	 *
+	 * @param integer|array|string|null $id     ID
+	 * @param array|null                $data   Data
+	 * @param boolean|null              $escape Escape
+	 *
+	 * @return boolean
+	 */
+	abstract protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool;
+
+	/**
+	 * Compiles an update and runs the query
+	 * This methods works only with dbCalls
+	 *
+	 * @param array|null  $set       An associative array of update values
+	 * @param string|null $index     The where key
+	 * @param integer     $batchSize The size of the batch to run
+	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
+	 *
+	 * @return mixed    Number of rows affected or FALSE on failure
+	 *
+	 * @throws DatabaseException
+	 */
+	abstract protected function doUpdateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false);
+
+	/**
+	 * Deletes a single record from the database where $id matches
+	 * This methods works only with dbCalls
+	 *
+	 * @param integer|string|array|null $id    The rows primary key(s)
+	 * @param boolean                   $purge Allows overriding the soft deletes setting.
+	 *
+	 * @return object|boolean
+	 *
+	 * @throws DatabaseException
+	 */
+	abstract protected function doDelete($id = null, bool $purge = false);
+
+	/**
+	 * Permanently deletes all rows that have been marked as deleted
+	 * through soft deletes (deleted = 1)
+	 * This methods works only with dbCalls
+	 *
+	 * @return boolean|mixed
+	 */
+	abstract protected function doPurgeDeleted();
+
+	/**
+	 * Works with the find* methods to return only the rows that
+	 * have been deleted.
+	 * This methods works only with dbCalls
+	 *
+	 * @return void
+	 */
+	abstract protected function doOnlyDeleted();
+
+	/**
+	 * Compiles a replace and runs the query
+	 * This methods works only with dbCalls
+	 *
+	 * @param array|null $data      Data
+	 * @param boolean    $returnSQL Set to true to return Query String
+	 *
+	 * @return mixed
+	 */
+	abstract protected function doReplace(array $data = null, bool $returnSQL = false);
+
+	/**
+	 * Grabs the last error(s) that occurred from the Database connection.
+	 * This methods works only with dbCalls
+	 *
+	 * @return array|null
+	 */
+	abstract protected function doErrors();
+
+	/**
+	 * Override countAllResults to account for soft deleted accounts.
+	 * This methods works only with dbCalls
+	 *
+	 * @param boolean $reset Reset
+	 * @param boolean $test  Test
+	 *
+	 * @return mixed
+	 */
+	abstract public function countAllResults(bool $reset = true, bool $test = false);
+
+	/**
+	 * Loops over records in batches, allowing you to operate on them.
+	 * This methods works only with dbCalls
+	 *
+	 * @param integer $size     Size
+	 * @param Closure $userFunc Callback Function
+	 *
+	 * @return void
+	 *
+	 * @throws DataException
+	 */
+	abstract public function chunk(int $size, Closure $userFunc);
+
+	// endregion
+
+	// region CRUD & Finders
 
 	/**
 	 * Fetches the row of database
@@ -348,17 +541,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Fetches the row of database
-	 * This methods works only with dbCalls
-	 *
-	 * @param boolean                   $singleton Single or multiple results
-	 * @param array|integer|string|null $id        One primary key or an array of primary keys
-	 *
-	 * @return array|object|null The resulting row of data, or null.
-	 */
-	abstract protected function doFind(bool $singleton, $id = null);
-
-	/**
 	 * Fetches the column of database
 	 *
 	 * @param string $columnName Column Name
@@ -378,18 +560,6 @@ abstract class BaseModel
 
 		return $resultSet ? array_column($resultSet, $columnName) : null;
 	}
-
-	/**
-	 * Fetches the column of database
-	 * This methods works only with dbCalls
-	 *
-	 * @param string $columnName Column Name
-	 *
-	 * @return array|null The resulting row of data, or null if no data found.
-	 *
-	 * @throws DataException
-	 */
-	abstract protected function doFindColumn(string $columnName);
 
 	/**
 	 * Fetches all results, while optionally limiting them.
@@ -438,17 +608,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Fetches all results, while optionally limiting them.
-	 * This methods works only with dbCalls
-	 *
-	 * @param integer $limit  Limit
-	 * @param integer $offset Offset
-	 *
-	 * @return array
-	 */
-	abstract protected function doFindAll(int $limit = 0, int $offset = 0);
-
-	/**
 	 * Returns the first row of the result set.
 	 *
 	 * @return array|object|null
@@ -488,14 +647,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Returns the first row of the result set.
-	 * This methods works only with dbCalls
-	 *
-	 * @return array|object|null
-	 */
-	abstract protected function doFirst();
-
-	/**
 	 * A convenience method that will attempt to determine whether the
 	 * data should be inserted or updated. Will work with either
 	 * an array or object. When using with custom class objects,
@@ -514,110 +665,6 @@ abstract class BaseModel
 		}
 
 		return $this->doSave($data);
-	}
-
-	/**
-	 * A convenience method that will attempt to determine whether the
-	 * data should be inserted or updated. Will work with either
-	 * an array or object. When using with custom class objects,
-	 * you must ensure that the class will provide access to the class
-	 * variables, even if through a magic method.
-	 * This methods works only with dbCalls
-	 *
-	 * @param array|object $data Data
-	 *
-	 * @return boolean
-	 *
-	 * @todo: to be reworked
-	 */
-	abstract protected function doSave($data): bool;
-
-	/**
-	 * Takes a class an returns an array of it's public and protected
-	 * properties as an array suitable for use in creates and updates.
-	 * This method use objectToRawArray internally and does conversion
-	 * to string on all Time instances
-	 *
-	 * @param string|object $data        Data
-	 * @param boolean       $onlyChanged Only Changed Property
-	 * @param boolean       $recursive   If true, inner entities will be casted as array as well
-	 *
-	 * @return array Array
-	 *
-	 * @throws ReflectionException
-	 */
-	protected function objectToArray($data, bool $onlyChanged = true, bool $recursive = false): array
-	{
-		$properties = $this->objectToRawArray($data, $onlyChanged, $recursive);
-
-		// Convert any Time instances to appropriate $dateFormat
-		if ($properties)
-		{
-			$properties = array_map(function ($value) {
-				if ($value instanceof Time)
-				{
-					switch ($this->dateFormat)
-					{
-						case 'datetime':
-							return $value->format('Y-m-d H:i:s');
-						case 'date':
-							return $value->format('Y-m-d');
-						case 'int':
-							return $value->getTimestamp();
-						default:
-							return (string) $value;
-					}
-				}
-				return $value;
-			}, $properties);
-		}
-
-		return $properties;
-	}
-
-	/**
-	 * Takes a class an returns an array of it's public and protected
-	 * properties as an array with raw values.
-	 *
-	 * @param string|object $data        Data
-	 * @param boolean       $onlyChanged Only Changed Property
-	 * @param boolean       $recursive   If true, inner entities will be casted as array as well
-	 *
-	 * @return array|null Array
-	 *
-	 * @throws ReflectionException
-	 */
-	protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
-	{
-		if (method_exists($data, 'toRawArray'))
-		{
-			$properties = $data->toRawArray($onlyChanged, $recursive);
-
-			// Always grab the primary key otherwise updates will fail.
-			if (! empty($properties) && ! empty($this->primaryKey) && ! in_array($this->primaryKey, $properties, true)
-				&& ! empty($data->{$this->primaryKey}))
-			{
-				$properties[$this->primaryKey] = $data->{$this->primaryKey};
-			}
-		}
-		else
-		{
-			$mirror = new ReflectionClass($data);
-			$props  = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
-
-			$properties = [];
-
-			// Loop over each property,
-			// saving the name/value in a new array we can return.
-			foreach ($props as $prop)
-			{
-				// Must make protected values accessible.
-				$prop->setAccessible(true);
-				$properties[$prop->getName()] = $prop->getValue($data);
-			}
-		}
-
-		return $properties;
 	}
 
 	/**
@@ -729,17 +776,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Inserts data into the current database
-	 * This methods works only with dbCalls
-	 *
-	 * @param array        $data   Data
-	 * @param boolean|null $escape Escape
-	 *
-	 * @return object|integer|string|false
-	 */
-	abstract protected function doInsert(array $data, ?bool $escape = null);
-
-	/**
 	 * Compiles batch insert runs the queries, validating each row prior.
 	 *
 	 * @param array|null   $set       an associative array of insert values
@@ -800,19 +836,6 @@ abstract class BaseModel
 
 		return $this->doInsertBatch($set, $escape, $batchSize, $testing);
 	}
-
-	/**
-	 * Compiles batch insert and runs the queries, validating each row prior.
-	 * This methods works only with dbCalls
-	 *
-	 * @param array|null   $set       An associative array of insert values
-	 * @param boolean|null $escape    Whether to escape values and identifiers
-	 * @param integer      $batchSize The size of the batch to run
-	 * @param boolean      $testing   True means only number of records is returned, false will execute the query
-	 *
-	 * @return integer|boolean Number of rows inserted or FALSE on failure
-	 */
-	abstract protected function doInsertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false);
 
 	/**
 	 * Updates a single record in the database. If an object is provided,
@@ -902,18 +925,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Updates a single record in the database.
-	 * This methods works only with dbCalls
-	 *
-	 * @param integer|array|string|null $id     ID
-	 * @param array|null                $data   Data
-	 * @param boolean|null              $escape Escape
-	 *
-	 * @return boolean
-	 */
-	abstract protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool;
-
-	/**
 	 * Compiles an update and runs the query
 	 *
 	 * @param array|null  $set       An associative array of update values
@@ -978,21 +989,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Compiles an update and runs the query
-	 * This methods works only with dbCalls
-	 *
-	 * @param array|null  $set       An associative array of update values
-	 * @param string|null $index     The where key
-	 * @param integer     $batchSize The size of the batch to run
-	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
-	 *
-	 * @return mixed    Number of rows affected or FALSE on failure
-	 *
-	 * @throws DatabaseException
-	 */
-	abstract protected function doUpdateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false);
-
-	/**
 	 * Deletes a single record from the database where $id matches
 	 *
 	 * @param integer|string|array|null $id    The rows primary key(s)
@@ -1037,19 +1033,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Deletes a single record from the database where $id matches
-	 * This methods works only with dbCalls
-	 *
-	 * @param integer|string|array|null $id    The rows primary key(s)
-	 * @param boolean                   $purge Allows overriding the soft deletes setting.
-	 *
-	 * @return object|boolean
-	 *
-	 * @throws DatabaseException
-	 */
-	abstract protected function doDelete($id = null, bool $purge = false);
-
-	/**
 	 * Permanently deletes all rows that have been marked as deleted
 	 * through soft deletes (deleted = 1)
 	 *
@@ -1064,15 +1047,6 @@ abstract class BaseModel
 
 		return $this->doPurgeDeleted();
 	}
-
-	/**
-	 * Permanently deletes all rows that have been marked as deleted
-	 * through soft deletes (deleted = 1)
-	 * This methods works only with dbCalls
-	 *
-	 * @return boolean|mixed
-	 */
-	abstract protected function doPurgeDeleted();
 
 	/**
 	 * Sets $useSoftDeletes value so that we can temporarily override
@@ -1104,15 +1078,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Works with the find* methods to return only the rows that
-	 * have been deleted.
-	 * This methods works only with dbCalls
-	 *
-	 * @return void
-	 */
-	abstract protected function doOnlyDeleted();
-
-	/**
 	 * Compiles a replace and runs the query
 	 *
 	 * @param array|null $data      Data
@@ -1132,61 +1097,35 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Compiles a replace and runs the query
-	 * This methods works only with dbCalls
+	 * Grabs the last error(s) that occurred. If data was validated,
+	 * it will first check for errors there, otherwise will try to
+	 * grab the last error from the Database connection.
 	 *
-	 * @param array|null $data      Data
-	 * @param boolean    $returnSQL Set to true to return Query String
+	 * @param boolean $forceDB Always grab the db error, not validation
 	 *
-	 * @return mixed
+	 * @return array|null
 	 */
-	abstract protected function doReplace(array $data = null, bool $returnSQL = false);
-
-	//--------------------------------------------------------------------
-	// Utility
-	//--------------------------------------------------------------------
-
-	/**
-	 * Sets the return type of the results to be as an associative array.
-	 *
-	 * @return $this
-	 */
-	public function asArray()
+	public function errors(bool $forceDB = false)
 	{
-		$this->tempReturnType = 'array';
+		// Do we have validation errors?
+		if (! $forceDB && ! $this->skipValidation)
+		{
+			$errors = $this->validation->getErrors();
 
-		return $this;
+			if (! empty($errors))
+			{
+				return $errors;
+			}
+		}
+
+		$error = $this->doErrors();
+
+		return $error['message'] ?? null;
 	}
 
-	/**
-	 * Sets the return type to be of the specified type of object.
-	 * Defaults to a simple object, but can be any class that has
-	 * class vars with the same name as the collection columns,
-	 * or at least allows them to be created.
-	 *
-	 * @param string $class Class Name
-	 *
-	 * @return $this
-	 */
-	public function asObject(string $class = 'object')
-	{
-		$this->tempReturnType = $class;
+	// endregion
 
-		return $this;
-	}
-
-	/**
-	 * Loops over records in batches, allowing you to operate on them.
-	 * This methods works only with dbCalls
-	 *
-	 * @param integer $size     Size
-	 * @param Closure $userFunc Callback Function
-	 *
-	 * @return void
-	 *
-	 * @throws DataException
-	 */
-	public abstract function chunk(int $size, Closure $userFunc);
+	// region Pager
 
 	/**
 	 * Works with Pager to get the size and offset parameters.
@@ -1216,6 +1155,24 @@ abstract class BaseModel
 		$offset      = ($page - 1) * $perPage;
 
 		return $this->findAll($perPage, $offset);
+	}
+
+	// endregion
+
+	// region Allowed Fields
+
+	/**
+	 * It could be used when you have to change default or override current allowed fields.
+	 *
+	 * @param array $allowedFields Array with names of fields
+	 *
+	 * @return $this
+	 */
+	public function setAllowedFields(array $allowedFields)
+	{
+		$this->allowedFields = $allowedFields;
+
+		return $this;
 	}
 
 	/**
@@ -1269,6 +1226,25 @@ abstract class BaseModel
 		return $data;
 	}
 
+	// endregion
+
+	// region Timestamps
+
+	/**
+	 * Sets the date or current date if null value is passed
+	 *
+	 * @param integer|null $userData An optional PHP timestamp to be converted.
+	 *
+	 * @return mixed
+	 *
+	 * @throws ModelException
+	 */
+	protected function setDate(?int $userData = null)
+	{
+		$currentDate = $userData ?? time();
+		return $this->intToDate($currentDate);
+	}
+
 	/**
 	 * A utility function to allow child models to use the type of
 	 * date/time format that they prefer. This is primarily used for
@@ -1280,81 +1256,57 @@ abstract class BaseModel
 	 *  - 'datetime' - Stores the data in the SQL datetime format
 	 *  - 'date'     - Stores the date (only) in the SQL date format.
 	 *
-	 * @param integer|null $userData An optional PHP timestamp to be converted.
+	 * @param integer $value value
 	 *
-	 * @return mixed
+	 * @return integer|string
 	 *
 	 * @throws ModelException
 	 */
-	protected function setDate(?int $userData = null)
+	protected function intToDate(int $value)
 	{
-		$currentDate = $userData ?? time();
-
 		switch ($this->dateFormat)
 		{
 			case 'int':
-				return $currentDate;
+				return $value;
 			case 'datetime':
-				return date('Y-m-d H:i:s', $currentDate);
+				return date('Y-m-d H:i:s', $value);
 			case 'date':
-				return date('Y-m-d', $currentDate);
+				return date('Y-m-d', $value);
 			default:
 				throw ModelException::forNoDateFormat(static::class);
 		}
 	}
 
 	/**
-	 * Grabs the last error(s) that occurred. If data was validated,
-	 * it will first check for errors there, otherwise will try to
-	 * grab the last error from the Database connection.
+	 * Converts Time value to string using $this->dateFormat
 	 *
-	 * @param boolean $forceDB Always grab the db error, not validation
+	 * The available time formats are:
+	 *  - 'int'      - Stores the date as an integer timestamp
+	 *  - 'datetime' - Stores the data in the SQL datetime format
+	 *  - 'date'     - Stores the date (only) in the SQL date format.
 	 *
-	 * @return array|null
+	 * @param Time $value value
+	 *
+	 * @return string|integer
 	 */
-	public function errors(bool $forceDB = false)
+	protected function timeToDate(Time $value)
 	{
-		// Do we have validation errors?
-		if (! $forceDB && ! $this->skipValidation)
+		switch ($this->dateFormat)
 		{
-			$errors = $this->validation->getErrors();
-
-			if (! empty($errors))
-			{
-				return $errors;
-			}
+			case 'datetime':
+				return $value->format('Y-m-d H:i:s');
+			case 'date':
+				return $value->format('Y-m-d');
+			case 'int':
+				return $value->getTimestamp();
+			default:
+				return (string) $value;
 		}
-
-		$error = $this->doErrors();
-
-		return $error['message'] ?? null;
 	}
 
-	/**
-	 * Grabs the last error(s) that occurred from the Database connection.
-	 * This methods works only with dbCalls
-	 *
-	 * @return array|null
-	 */
-	abstract protected function doErrors();
+	// endregion
 
-	/**
-	 * It could be used when you have to change default or override current allowed fields.
-	 *
-	 * @param array $allowedFields Array with names of fields
-	 *
-	 * @return $this
-	 */
-	public function setAllowedFields(array $allowedFields)
-	{
-		$this->allowedFields = $allowedFields;
-
-		return $this;
-	}
-
-	//--------------------------------------------------------------------
-	// Validation
-	//--------------------------------------------------------------------
+	// region Validation
 
 	/**
 	 * Set the value of the skipValidation flag.
@@ -1483,95 +1435,6 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Removes any rules that apply to fields that have not been set
-	 * currently so that rules don't block updating when only updating
-	 * a partial row.
-	 *
-	 * @param array      $rules Array containing field name and rule
-	 * @param array|null $data  Data
-	 *
-	 * @return array
-	 */
-	protected function cleanValidationRules(array $rules, array $data = null): array
-	{
-		if (empty($data))
-		{
-			return [];
-		}
-
-		foreach ($rules as $field => $rule)
-		{
-			if (! array_key_exists($field, $data))
-			{
-				unset($rules[$field]);
-			}
-		}
-
-		return $rules;
-	}
-
-	/**
-	 * Replace any placeholders within the rules with the values that
-	 * match the 'key' of any properties being set. For example, if
-	 * we had the following $data array:
-	 *
-	 * [ 'id' => 13 ]
-	 *
-	 * and the following rule:
-	 *
-	 *  'required|is_unique[users,email,id,{id}]'
-	 *
-	 * The value of {id} would be replaced with the actual id in the form data:
-	 *
-	 *  'required|is_unique[users,email,id,13]'
-	 *
-	 * @param array $rules Validation rules
-	 * @param array $data  Data
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @deprecated use fillPlaceholders($rules, $data) from Validation instead
-	 *
-	 * @return array
-	 */
-	protected function fillPlaceholders(array $rules, array $data): array
-	{
-		$replacements = [];
-
-		foreach ($data as $key => $value)
-		{
-			$replacements['{' . $key . '}'] = $value;
-		}
-
-		if (! empty($replacements))
-		{
-			foreach ($rules as &$rule)
-			{
-				if (is_array($rule))
-				{
-					foreach ($rule as &$row)
-					{
-						// Should only be an `errors` array
-						// which doesn't take placeholders.
-						if (is_array($row))
-						{
-							continue;
-						}
-
-						$row = strtr($row, $replacements);
-					}
-
-					continue;
-				}
-
-				$rule = strtr($rule, $replacements);
-			}
-		}
-
-		return $rules;
-	}
-
-	/**
 	 * Returns the model's defined validation rules so that they
 	 * can be used elsewhere, if needed.
 	 *
@@ -1615,15 +1478,36 @@ abstract class BaseModel
 	}
 
 	/**
-	 * Override countAllResults to account for soft deleted accounts.
-	 * This methods works only with dbCalls
+	 * Removes any rules that apply to fields that have not been set
+	 * currently so that rules don't block updating when only updating
+	 * a partial row.
 	 *
-	 * @param boolean $reset Reset
-	 * @param boolean $test  Test
+	 * @param array      $rules Array containing field name and rule
+	 * @param array|null $data  Data
 	 *
-	 * @return mixed
+	 * @return array
 	 */
-	abstract public function countAllResults(bool $reset = true, bool $test = false);
+	protected function cleanValidationRules(array $rules, array $data = null): array
+	{
+		if (empty($data))
+		{
+			return [];
+		}
+
+		foreach ($rules as $field => $rule)
+		{
+			if (! array_key_exists($field, $data))
+			{
+				unset($rules[$field]);
+			}
+		}
+
+		return $rules;
+	}
+
+	// endregion
+
+	// region Callbacks
 
 	/**
 	 * Sets $tempAllowCallbacks value so that we can temporarily override
@@ -1683,9 +1567,120 @@ abstract class BaseModel
 		return $eventData;
 	}
 
-	//--------------------------------------------------------------------
-	// Magic
-	//--------------------------------------------------------------------
+	// endregion
+
+	// region Utility
+
+	/**
+	 * Sets the return type of the results to be as an associative array.
+	 *
+	 * @return $this
+	 */
+	public function asArray()
+	{
+		$this->tempReturnType = 'array';
+
+		return $this;
+	}
+
+	/**
+	 * Sets the return type to be of the specified type of object.
+	 * Defaults to a simple object, but can be any class that has
+	 * class vars with the same name as the collection columns,
+	 * or at least allows them to be created.
+	 *
+	 * @param string $class Class Name
+	 *
+	 * @return $this
+	 */
+	public function asObject(string $class = 'object')
+	{
+		$this->tempReturnType = $class;
+
+		return $this;
+	}
+
+	/**
+	 * Takes a class an returns an array of it's public and protected
+	 * properties as an array suitable for use in creates and updates.
+	 * This method use objectToRawArray internally and does conversion
+	 * to string on all Time instances
+	 *
+	 * @param string|object $data        Data
+	 * @param boolean       $onlyChanged Only Changed Property
+	 * @param boolean       $recursive   If true, inner entities will be casted as array as well
+	 *
+	 * @return array Array
+	 *
+	 * @throws ReflectionException
+	 */
+	protected function objectToArray($data, bool $onlyChanged = true, bool $recursive = false): array
+	{
+		$properties = $this->objectToRawArray($data, $onlyChanged, $recursive);
+
+		// Convert any Time instances to appropriate $dateFormat
+		if ($properties)
+		{
+			$properties = array_map(function ($value) {
+				if ($value instanceof Time)
+				{
+					return $this->timeToDate($value);
+				}
+				return $value;
+			}, $properties);
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Takes a class an returns an array of it's public and protected
+	 * properties as an array with raw values.
+	 *
+	 * @param string|object $data        Data
+	 * @param boolean       $onlyChanged Only Changed Property
+	 * @param boolean       $recursive   If true, inner entities will be casted as array as well
+	 *
+	 * @return array|null Array
+	 *
+	 * @throws ReflectionException
+	 */
+	protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
+	{
+		if (method_exists($data, 'toRawArray'))
+		{
+			$properties = $data->toRawArray($onlyChanged, $recursive);
+
+			// Always grab the primary key otherwise updates will fail.
+			if (! empty($properties) && ! empty($this->primaryKey) && ! in_array($this->primaryKey, $properties, true)
+				&& ! empty($data->{$this->primaryKey}))
+			{
+				$properties[$this->primaryKey] = $data->{$this->primaryKey};
+			}
+		}
+		else
+		{
+			$mirror = new ReflectionClass($data);
+			$props  = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
+
+			$properties = [];
+
+			// Loop over each property,
+			// saving the name/value in a new array we can return.
+			foreach ($props as $prop)
+			{
+				// Must make protected values accessible.
+				$prop->setAccessible(true);
+				$properties[$prop->getName()] = $prop->getValue($data);
+			}
+		}
+
+		return $properties;
+	}
+
+	// endregion
+
+	// region Magic
 
 	/**
 	 * Provides the db connection and model's properties.
@@ -1750,4 +1745,71 @@ abstract class BaseModel
 
 		return $result;
 	}
+
+	// endregion
+
+	// region Deprecated
+
+	/**
+	 * Replace any placeholders within the rules with the values that
+	 * match the 'key' of any properties being set. For example, if
+	 * we had the following $data array:
+	 *
+	 * [ 'id' => 13 ]
+	 *
+	 * and the following rule:
+	 *
+	 *  'required|is_unique[users,email,id,{id}]'
+	 *
+	 * The value of {id} would be replaced with the actual id in the form data:
+	 *
+	 *  'required|is_unique[users,email,id,13]'
+	 *
+	 * @param array $rules Validation rules
+	 * @param array $data  Data
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @deprecated use fillPlaceholders($rules, $data) from Validation instead
+	 *
+	 * @return array
+	 */
+	protected function fillPlaceholders(array $rules, array $data): array
+	{
+		$replacements = [];
+
+		foreach ($data as $key => $value)
+		{
+			$replacements['{' . $key . '}'] = $value;
+		}
+
+		if (! empty($replacements))
+		{
+			foreach ($rules as &$rule)
+			{
+				if (is_array($rule))
+				{
+					foreach ($rule as &$row)
+					{
+						// Should only be an `errors` array
+						// which doesn't take placeholders.
+						if (is_array($row))
+						{
+							continue;
+						}
+
+						$row = strtr($row, $replacements);
+					}
+
+					continue;
+				}
+
+				$rule = strtr($rule, $replacements);
+			}
+		}
+
+		return $rules;
+	}
+
+	// endregion
 }

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -377,7 +377,7 @@ abstract class BaseModel
 	 *
 	 * @return array|object|null    The resulting row of data, or null.
 	 */
-	protected abstract function _find(bool $singleton, $id = null);
+	abstract protected function _find(bool $singleton, $id = null);
 
 	/**
 	 * Fetches the column of database from $this->table
@@ -407,7 +407,7 @@ abstract class BaseModel
 	 * @return array|null   The resulting row of data, or null if no data found.
 	 * @throws DataException Data Exception.
 	 */
-	protected abstract function _findColumn(string $columnName);
+	abstract protected function _findColumn(string $columnName);
 
 	/**
 	 * Works with the current Query Builder instance to return
@@ -465,7 +465,7 @@ abstract class BaseModel
 	 *
 	 * @return array
 	 */
-	protected abstract function _findAll(int $limit = 0, int $offset = 0);
+	abstract protected function _findAll(int $limit = 0, int $offset = 0);
 
 	/**
 	 * Returns the first row of the result set. Will take any previous
@@ -513,7 +513,7 @@ abstract class BaseModel
 	 *
 	 * @return array|object|null
 	 */
-	protected abstract function _first();
+	abstract protected function _first();
 
 	/**
 	 * Captures the builder's set() method so that we can validate the
@@ -568,7 +568,7 @@ abstract class BaseModel
 	 *
 	 * @return boolean
 	 */
-	protected abstract function _save($data): bool;
+	abstract protected function _save($data): bool;
 
 	/**
 	 * Takes a class an returns an array of it's public and protected
@@ -780,7 +780,7 @@ abstract class BaseModel
 	 *
 	 * @return object|integer|string|false
 	 */
-	protected abstract function _insert($data, ?bool $escape = null);
+	abstract protected function _insert($data, ?bool $escape = null);
 
 	/**
 	 * Compiles batch insert strings and runs the queries, validating each row prior.
@@ -854,7 +854,7 @@ abstract class BaseModel
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
 	 * @throws ReflectionException ReflectionException.
 	 */
-	protected abstract function _insertBatch(
+	abstract protected function _insertBatch(
 		array $set = null,
 		bool $escape = null,
 		int $batchSize = 100,
@@ -965,7 +965,7 @@ abstract class BaseModel
 	 *
 	 * @return boolean
 	 */
-	protected abstract function _update($id = null, $data = null, ?bool $escape = null): bool;
+	abstract protected function _update($id = null, $data = null, ?bool $escape = null): bool;
 
 	/**
 	 * Update_Batch
@@ -1046,7 +1046,7 @@ abstract class BaseModel
 	 * @throws DatabaseException DatabaseException.
 	 * @throws ReflectionException ReflectionException.
 	 */
-	protected abstract function _updateBatch(
+	abstract protected function _updateBatch(
 		array $set = null,
 		string $index = null,
 		int $batchSize = 100,
@@ -1107,7 +1107,7 @@ abstract class BaseModel
 	 * @return object|boolean
 	 * @throws DatabaseException DatabaseException.
 	 */
-	protected abstract function _delete($id = null, bool $purge = false);
+	abstract protected function _delete($id = null, bool $purge = false);
 
 	/**
 	 * Permanently deletes all rows that have been marked as deleted
@@ -1131,7 +1131,7 @@ abstract class BaseModel
 	 *
 	 * @return boolean|mixed
 	 */
-	protected abstract function _purgeDeleted();
+	abstract protected function _purgeDeleted();
 
 	/**
 	 * Sets $useSoftDeletes value so that we can temporarily override
@@ -1168,7 +1168,7 @@ abstract class BaseModel
 	 *
 	 * @return void
 	 */
-	protected abstract function _onlyDeleted();
+	abstract protected function _onlyDeleted();
 
 	/**
 	 * Replace
@@ -1201,7 +1201,7 @@ abstract class BaseModel
 	 *
 	 * @return mixed
 	 */
-	protected abstract function _replace(array $data = null, bool $returnSQL = false);
+	abstract protected function _replace(array $data = null, bool $returnSQL = false);
 
 	//--------------------------------------------------------------------
 	// Utility
@@ -1409,7 +1409,7 @@ abstract class BaseModel
 	 *
 	 * @return array|null
 	 */
-	protected abstract function _errors();
+	abstract protected function _errors();
 
 	/**
 	 * It could be used when you have to change default or override current allowed fields.

--- a/system/BaseModel.php
+++ b/system/BaseModel.php
@@ -290,12 +290,9 @@ abstract class BaseModel
 	/**
 	 * BaseModel constructor.
 	 *
-	 * @param object|null              $db         DB Connection
 	 * @param ValidationInterface|null $validation Validation
-	 *
-	 * @phpstan-ignore-next-line
 	 */
-	public function __construct(object &$db = null, ValidationInterface $validation = null)
+	public function __construct(ValidationInterface $validation = null)
 	{
 		$this->tempReturnType     = $this->returnType;
 		$this->tempUseSoftDeletes = $this->useSoftDeletes;

--- a/system/Model.php
+++ b/system/Model.php
@@ -289,11 +289,10 @@ class Model extends BaseModel
 	}
 
 	/**
-	 * Inserts data into the current table. If an object is provided,
-	 * it will attempt to convert it to an array.
+	 * Inserts data into the current table.
 	 * This methods works only with dbCalls
 	 *
-	 * @param array|object $data   Data
+	 * @param array        $data   Data
 	 * @param boolean|null $escape Escape
 	 *
 	 * @return BaseResult|integer|string|false

--- a/system/Model.php
+++ b/system/Model.php
@@ -90,9 +90,16 @@ class Model extends BaseModel
 	 */
 	public function __construct(ConnectionInterface &$db = null, ValidationInterface $validation = null)
 	{
-		parent::__construct($db, $validation);
+		parent::__construct($validation);
 
-		$this->db = $db ?? Database::connect($this->DBGroup);
+		if (is_null($db))
+		{
+			$this->db = Database::connect($this->DBGroup);
+		}
+		else
+		{
+			$this->db = &$db;
+		}
 	}
 
 	//--------------------------------------------------------------------

--- a/system/Model.php
+++ b/system/Model.php
@@ -469,7 +469,8 @@ class Model extends BaseModel
 		{
 			return $data->{$this->primaryKey};
 		}
-		elseif (is_array($data) && ! empty($data[$this->primaryKey]))
+
+		if (is_array($data) && ! empty($data[$this->primaryKey]))
 		{
 			return $data[$this->primaryKey];
 		}

--- a/system/Model.php
+++ b/system/Model.php
@@ -30,17 +30,14 @@ use ReflectionProperty;
 /**
  * Class Model
  *
- * The Model class provides a number of convenient features that
- * makes working with a database table less painful.
+ * The Model class extends BaseModel and provides additional
+ * convenient features that makes working with a SQL database
+ * table less painful.
  *
  * It will:
  *      - automatically connect to database
- *      - allow intermingling calls between db connection, the builder,
- *          and methods in this class.
- *      - simplifies pagination
+ *      - allow intermingling calls to the builder
  *      - removes the need to use Result object directly in most cases
- *      - allow specifying the return type (array, object, etc) with each call
- *      - ensure validation is run against objects when saving items
  *
  * @property ConnectionInterface $db
  *

--- a/system/Model.php
+++ b/system/Model.php
@@ -151,7 +151,7 @@ class Model extends BaseModel
 	 *
 	 * @param string $columnName Column Name
 	 *
-	 * @return array|null   The resulting row of data, or null if no data found.
+	 * @return array|null The resulting row of data, or null if no data found.
 	 */
 	protected function doFindColumn(string $columnName)
 	{
@@ -248,6 +248,8 @@ class Model extends BaseModel
 	 *
 	 * @return boolean
 	 *
+	 * @throws ReflectionException
+	 *
 	 * @todo rework to be in BaseModel
 	 */
 	protected function doSave($data): bool
@@ -306,7 +308,8 @@ class Model extends BaseModel
 	 * @param boolean       $recursive   If true, inner entities will be casted as array as well
 	 *
 	 * @return array|null Array
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	protected function objectToRawArray($data, bool $onlyChanged = true, bool $recursive = false): ?array
 	{
@@ -334,7 +337,8 @@ class Model extends BaseModel
 	 * @param boolean|null      $escape   Escape
 	 *
 	 * @return BaseResult|object|integer|string|false
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	public function insert($data = null, bool $returnID = true, ?bool $escape = null)
 	{
@@ -357,7 +361,7 @@ class Model extends BaseModel
 	 *
 	 * @return BaseResult|integer|string|false
 	 */
-	protected function doInsert($data, ?bool $escape = null)
+	protected function doInsert(array $data, ?bool $escape = null)
 	{
 		// Require non empty primaryKey when
 		// not using auto-increment feature
@@ -380,7 +384,8 @@ class Model extends BaseModel
 			}
 			else
 			{
-				$this->insertID = $this->db->insertID(); // @phpstan-ignore-line
+				// @phpstan-ignore-next-line
+				$this->insertID = $this->db->insertID();
 			}
 		}
 
@@ -397,14 +402,8 @@ class Model extends BaseModel
 	 * @param boolean      $testing   True means only number of records is returned, false will execute the query
 	 *
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
-	 * @throws ReflectionException ReflectionException.
 	 */
-	protected function doInsertBatch(
-		?array $set = null,
-		?bool $escape = null,
-		int $batchSize = 100,
-		bool $testing = false
-	)
+	protected function doInsertBatch(?array $set = null, ?bool $escape = null, int $batchSize = 100, bool $testing = false)
 	{
 		if (is_array($set))
 		{
@@ -431,7 +430,8 @@ class Model extends BaseModel
 	 * @param boolean|null              $escape Escape
 	 *
 	 * @return boolean
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
 	 */
 	public function update($id = null, $data = null, ?bool $escape = null): bool
 	{
@@ -480,15 +480,10 @@ class Model extends BaseModel
 	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
 	 *
 	 * @return mixed    Number of rows affected or FALSE on failure
-	 * @throws DatabaseException DatabaseException.
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws DatabaseException
 	 */
-	protected function doUpdateBatch(
-		array $set = null,
-		string $index = null,
-		int $batchSize = 100,
-		bool $returnSQL = false
-	)
+	protected function doUpdateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
 	{
 		return $this->builder()->testMode($returnSQL)->updateBatch($set, $index, $batchSize);
 	}
@@ -502,7 +497,8 @@ class Model extends BaseModel
 	 * @param boolean                   $purge Allows overriding the soft deletes setting.
 	 *
 	 * @return BaseResult|boolean
-	 * @throws DatabaseException DatabaseException.
+	 *
+	 * @throws DatabaseException
 	 */
 	protected function doDelete($id = null, bool $purge = false)
 	{
@@ -524,7 +520,9 @@ class Model extends BaseModel
 					);
 				}
 
-				return false; // @codeCoverageIgnore
+				// @codeCoverageIgnoreStart
+				return false;
+				// @codeCoverageIgnoreEnd
 			}
 
 			$set[$this->deletedField] = $this->setDate();
@@ -597,9 +595,9 @@ class Model extends BaseModel
 	 * @param integer $size     Size
 	 * @param Closure $userFunc Callback Function
 	 *
-	 * @throws DataException DataException.
-	 *
 	 * @return void
+	 *
+	 * @throws DataException
 	 */
 	public function chunk(int $size, Closure $userFunc)
 	{
@@ -638,12 +636,11 @@ class Model extends BaseModel
 	/**
 	 * Provides a shared instance of the Query Builder.
 	 *
-	 * @param string $table
+	 * @param string|null $table Table name
 	 *
 	 * @return BaseBuilder
-	 * @throws ModelException
 	 */
-	public function builder(string $table = null)
+	public function builder(?string $table = null)
 	{
 		// Check for an existing Builder
 		if ($this->builder instanceof BaseBuilder)
@@ -830,7 +827,10 @@ class Model extends BaseModel
 	 * @param boolean       $onlyChanged Only Changed
 	 *
 	 * @return array
-	 * @throws ReflectionException ReflectionException.
+	 *
+	 * @throws ReflectionException
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @deprecated since 4.1
 	 */

--- a/system/Model.php
+++ b/system/Model.php
@@ -92,7 +92,7 @@ class Model extends BaseModel
 	 *
 	 * @return array|object|null    The resulting row of data, or null.
 	 */
-	protected function _find(bool $singleton, $id = null)
+	protected function doFind(bool $singleton, $id = null)
 	{
 		$builder = $this->builder();
 
@@ -128,7 +128,7 @@ class Model extends BaseModel
 	 *
 	 * @return array|null   The resulting row of data, or null if no data found.
 	 */
-	protected function _findColumn(string $columnName)
+	protected function doFindColumn(string $columnName)
 	{
 		return $this->select($columnName)->asArray()->find();
 	}
@@ -142,7 +142,7 @@ class Model extends BaseModel
 	 *
 	 * @return array
 	 */
-	protected function _findAll(int $limit = 0, int $offset = 0)
+	protected function doFindAll(int $limit = 0, int $offset = 0)
 	{
 		$builder = $this->builder();
 
@@ -162,7 +162,7 @@ class Model extends BaseModel
 	 *
 	 * @return array|object|null
 	 */
-	protected function _first()
+	protected function doFirst()
 	{
 		$builder = $this->builder();
 
@@ -199,7 +199,7 @@ class Model extends BaseModel
 	 *
 	 * @return boolean
 	 */
-	protected function _save($data): bool
+	protected function doSave($data): bool
 	{
 		// When useAutoIncrement feature is disabled check
 		// in the database if given record already exists
@@ -283,7 +283,7 @@ class Model extends BaseModel
 	 *
 	 * @return BaseResult|integer|string|false
 	 */
-	protected function _insert($data, bool $escape = null)
+	protected function doInsert($data, bool $escape = null)
 	{
 		// Require non empty primaryKey when
 		// not using auto-increment feature
@@ -324,7 +324,7 @@ class Model extends BaseModel
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
 	 * @throws ReflectionException ReflectionException.
 	 */
-	protected function _insertBatch(
+	protected function doInsertBatch(
 		array $set = null,
 		bool $escape = null,
 		int $batchSize = 100,
@@ -357,7 +357,7 @@ class Model extends BaseModel
 	 *
 	 * @return boolean
 	 */
-	protected function _update($id = null, $data = null, ?bool $escape = null): bool
+	protected function doUpdate($id = null, $data = null, ?bool $escape = null): bool
 	{
 		$builder = $this->builder();
 
@@ -386,7 +386,7 @@ class Model extends BaseModel
 	 * @throws DatabaseException DatabaseException.
 	 * @throws ReflectionException ReflectionException.
 	 */
-	protected function _updateBatch(
+	protected function doUpdateBatch(
 		array $set = null,
 		string $index = null,
 		int $batchSize = 100,
@@ -406,7 +406,7 @@ class Model extends BaseModel
 	 * @return BaseResult|boolean
 	 * @throws DatabaseException DatabaseException.
 	 */
-	protected function _delete($id = null, bool $purge = false)
+	protected function doDelete($id = null, bool $purge = false)
 	{
 		$builder = $this->builder();
 
@@ -452,7 +452,7 @@ class Model extends BaseModel
 	 *
 	 * @return boolean|mixed
 	 */
-	protected function _purgeDeleted()
+	protected function doPurgeDeleted()
 	{
 		return $this->builder()
 			->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
@@ -465,7 +465,7 @@ class Model extends BaseModel
 	 *
 	 * @return void
 	 */
-	protected function _onlyDeleted()
+	protected function doOnlyDeleted()
 	{
 		$this->builder()->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
 	}
@@ -480,7 +480,7 @@ class Model extends BaseModel
 	 *
 	 * @return mixed
 	 */
-	protected function _replace(array $data = null, bool $returnSQL = false)
+	protected function doReplace(array $data = null, bool $returnSQL = false)
 	{
 		return $this->builder()->testMode($returnSQL)->replace($data);
 	}
@@ -589,7 +589,7 @@ class Model extends BaseModel
 	 *
 	 * @return array|null
 	 */
-	protected function _errors()
+	protected function doErrors()
 	{
 		return $this->db->error();
 	}

--- a/system/Model.php
+++ b/system/Model.php
@@ -210,6 +210,8 @@ class Model extends BaseModel
 	 * @param array|object $data Data
 	 *
 	 * @return boolean
+	 *
+	 * @todo rework to be in BaseModel
 	 */
 	protected function doSave($data): bool
 	{
@@ -362,12 +364,11 @@ class Model extends BaseModel
 	}
 
 	/**
-	 * Updates a single record in $this->table. If an object is provided,
-	 * it will attempt to convert it into an array.
+	 * Updates a single record in $this->table.
 	 * This methods works only with dbCalls
 	 *
 	 * @param integer|array|string|null $id     ID
-	 * @param array|object|null         $data   Data
+	 * @param array|null                $data   Data
 	 * @param boolean|null              $escape Escape
 	 *
 	 * @return boolean

--- a/system/Model.php
+++ b/system/Model.php
@@ -49,6 +49,13 @@ use ReflectionProperty;
 class Model extends BaseModel
 {
 	/**
+	 * Name of database table
+	 *
+	 * @var string
+	 */
+	protected $table;
+
+	/**
 	 * The table's primary key.
 	 *
 	 * @var string
@@ -595,6 +602,20 @@ class Model extends BaseModel
 	protected function doErrors()
 	{
 		return $this->db->error();
+	}
+
+	/**
+	 * Specify the table associated with a model
+	 *
+	 * @param string $table Table
+	 *
+	 * @return $this
+	 */
+	public function setTable(string $table)
+	{
+		$this->table = $table;
+
+		return $this;
 	}
 
 	/**

--- a/system/Model.php
+++ b/system/Model.php
@@ -45,8 +45,6 @@ use ReflectionProperty;
  */
 class Model extends BaseModel
 {
-	// region Properties
-
 	/**
 	 * Name of database table
 	 *
@@ -69,6 +67,13 @@ class Model extends BaseModel
 	protected $useAutoIncrement = true;
 
 	/**
+	 * Database Connection
+	 *
+	 * @var ConnectionInterface
+	 */
+	protected $db;
+
+	/**
 	 * Query Builder object
 	 *
 	 * @var BaseBuilder|null
@@ -83,10 +88,6 @@ class Model extends BaseModel
 	 * @var array
 	 */
 	protected $tempData = [];
-
-	// endregion
-
-	// region Constructor
 
 	/**
 	 * Model constructor.
@@ -108,10 +109,6 @@ class Model extends BaseModel
 		}
 	}
 
-	// endregion
-
-	// region Setters
-
 	/**
 	 * Specify the table associated with a model
 	 *
@@ -125,10 +122,6 @@ class Model extends BaseModel
 
 		return $this;
 	}
-
-	// endregion
-
-	// region Database Methods
 
 	/**
 	 * Fetches the row of database from $this->table with a primary key
@@ -550,10 +543,6 @@ class Model extends BaseModel
 		return $this->builder()->testMode($test)->countAllResults($reset);
 	}
 
-	// endregion
-
-	// region Builder
-
 	/**
 	 * Provides a shared instance of the Query Builder.
 	 *
@@ -623,12 +612,6 @@ class Model extends BaseModel
 		return $this;
 	}
 
-	// endregion
-
-	// region Overrides
-
-	// region CRUD & Finders
-
 	/**
 	 * This method is called on save to determine if entry have to be updated
 	 * If this method return false insert operation will be executed
@@ -696,10 +679,6 @@ class Model extends BaseModel
 		return parent::update($id, $data, $escape);
 	}
 
-	// endregion
-
-	// region Utility
-
 	/**
 	 * Takes a class an returns an array of it's public and protected
 	 * properties as an array with raw values.
@@ -728,10 +707,6 @@ class Model extends BaseModel
 
 		return $properties;
 	}
-
-	// endregion
-
-	// region Magic
 
 	/**
 	 * Provides/instantiates the builder/db connection and model's table/primary key names and return type.
@@ -815,14 +790,8 @@ class Model extends BaseModel
 		return $result;
 	}
 
-	// endregion
-
-	// endregion
-
-	// region Deprecated
-
 	/**
-	 * Takes a class an returns an array of it's public and protected
+	 * Takes a class and returns an array of it's public and protected
 	 * properties as an array suitable for use in creates and updates.
 	 *
 	 * @param string|object $data        Data
@@ -896,7 +865,4 @@ class Model extends BaseModel
 
 		return $properties;
 	}
-
-	// endregion
-
 }

--- a/system/Model.php
+++ b/system/Model.php
@@ -96,6 +96,7 @@ class Model extends BaseModel
 	/**
 	 * Fetches the row of database from $this->table with a primary key
 	 * matching $id. This methods works only with dbCalls
+	 * This methods works only with dbCalls
 	 *
 	 * @param boolean                   $singleton Single or multiple results
 	 * @param array|integer|string|null $id        One primary key or an array of primary keys
@@ -133,6 +134,7 @@ class Model extends BaseModel
 
 	/**
 	 * Fetches the column of database from $this->table
+	 * This methods works only with dbCalls
 	 *
 	 * @param string $columnName Column Name
 	 *
@@ -146,6 +148,7 @@ class Model extends BaseModel
 	/**
 	 * Works with the current Query Builder instance to return
 	 * all results, while optionally limiting them.
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer $limit  Limit
 	 * @param integer $offset Offset
@@ -169,6 +172,7 @@ class Model extends BaseModel
 	/**
 	 * Returns the first row of the result set. Will take any previous
 	 * Query Builder calls into account when determining the result set.
+	 * This methods works only with dbCalls
 	 *
 	 * @return array|object|null
 	 */
@@ -204,6 +208,7 @@ class Model extends BaseModel
 	 * an array or object. When using with custom class objects,
 	 * you must ensure that the class will provide access to the class
 	 * variables, even if through a magic method.
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|object $data Data
 	 *
@@ -287,6 +292,7 @@ class Model extends BaseModel
 	/**
 	 * Inserts data into the current table. If an object is provided,
 	 * it will attempt to convert it to an array.
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|object $data   Data
 	 * @param boolean|null $escape Escape
@@ -325,6 +331,7 @@ class Model extends BaseModel
 
 	/**
 	 * Compiles batch insert strings and runs the queries, validating each row prior.
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|null $set       An associative array of insert values
 	 * @param boolean    $escape    Whether to escape values and identifiers
@@ -360,6 +367,7 @@ class Model extends BaseModel
 	/**
 	 * Updates a single record in $this->table. If an object is provided,
 	 * it will attempt to convert it into an array.
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer|array|string|null $id     ID
 	 * @param array|object|null         $data   Data
@@ -383,9 +391,8 @@ class Model extends BaseModel
 	}
 
 	/**
-	 * Update_Batch
-	 *
 	 * Compiles an update string and runs the query
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|null  $set       An associative array of update values
 	 * @param string|null $index     The where key
@@ -409,6 +416,7 @@ class Model extends BaseModel
 	/**
 	 * Deletes a single record from $this->table where $id matches
 	 * the table's primaryKey
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer|string|array|null $id    The rows primary key(s)
 	 * @param boolean                   $purge Allows overriding the soft deletes setting.
@@ -459,6 +467,7 @@ class Model extends BaseModel
 	/**
 	 * Permanently deletes all rows that have been marked as deleted
 	 * through soft deletes (deleted = 1)
+	 * This methods works only with dbCalls
 	 *
 	 * @return boolean|mixed
 	 */
@@ -472,6 +481,7 @@ class Model extends BaseModel
 	/**
 	 * Works with the find* methods to return only the rows that
 	 * have been deleted.
+	 * This methods works only with dbCalls
 	 *
 	 * @return void
 	 */
@@ -481,9 +491,8 @@ class Model extends BaseModel
 	}
 
 	/**
-	 * Replace
-	 *
 	 * Compiles a replace into string and runs the query
+	 * This methods works only with dbCalls
 	 *
 	 * @param array|null $data      Data
 	 * @param boolean    $returnSQL Set to true to return Query String
@@ -503,6 +512,7 @@ class Model extends BaseModel
 	 * Loops over records in batches, allowing you to operate on them.
 	 * Works with $this->builder to get the Compiled select to
 	 * determine the rows to operate on.
+	 * This methods works only with dbCalls
 	 *
 	 * @param integer $size     Size
 	 * @param Closure $userFunc Callback Function
@@ -596,6 +606,7 @@ class Model extends BaseModel
 
 	/**
 	 * Grabs the last error(s) that occurred from the Database connection.
+	 * This methods works only with dbCalls
 	 *
 	 * @return array|null
 	 */

--- a/system/Model.php
+++ b/system/Model.php
@@ -20,15 +20,9 @@ use CodeIgniter\Database\ConnectionInterface;
 use CodeIgniter\Database\Exceptions\DatabaseException;
 use CodeIgniter\Database\Exceptions\DataException;
 use CodeIgniter\Exceptions\ModelException;
-use CodeIgniter\I18n\Time;
-use CodeIgniter\Pager\Pager;
 use CodeIgniter\Validation\ValidationInterface;
 use Config\Database;
-use Config\Services;
-use ReflectionClass;
 use ReflectionException;
-use ReflectionProperty;
-use stdClass;
 
 /**
  * Class Model
@@ -47,23 +41,8 @@ use stdClass;
  *
  * @mixin BaseBuilder
  */
-class Model
+class Model extends BaseModel
 {
-	/**
-	 * Pager instance.
-	 * Populated after calling $this->paginate()
-	 *
-	 * @var Pager
-	 */
-	public $pager;
-
-	/**
-	 * Name of database table
-	 *
-	 * @var string
-	 */
-	protected $table;
-
 	/**
 	 * The table's primary key.
 	 *
@@ -79,54 +58,6 @@ class Model
 	protected $useAutoIncrement = true;
 
 	/**
-	 * Last insert ID
-	 *
-	 * @var integer|string
-	 */
-	protected $insertID = 0;
-
-	/**
-	 * The Database connection group that
-	 * should be instantiated.
-	 *
-	 * @var string
-	 */
-	protected $DBGroup;
-
-	/**
-	 * The format that the results should be returned as.
-	 * Will be overridden if the as* methods are used.
-	 *
-	 * @var string
-	 */
-	protected $returnType = 'array';
-
-	/**
-	 * If this model should use "softDeletes" and
-	 * simply set a date when rows are deleted, or
-	 * do hard deletes.
-	 *
-	 * @var boolean
-	 */
-	protected $useSoftDeletes = false;
-
-	/**
-	 * An array of field names that are allowed
-	 * to be set by the user in inserts/updates.
-	 *
-	 * @var array
-	 */
-	protected $allowedFields = [];
-
-	/**
-	 * If true, will set created_at, and updated_at
-	 * values during insert and update routines.
-	 *
-	 * @var boolean
-	 */
-	protected $useTimestamps = false;
-
-	/**
 	 * The type of column that created_at and updated_at
 	 * are expected to.
 	 *
@@ -135,51 +66,6 @@ class Model
 	 * @var string
 	 */
 	protected $dateFormat = 'datetime';
-
-	/**
-	 * The column used for insert timestamps
-	 *
-	 * @var string
-	 */
-	protected $createdField = 'created_at';
-
-	/**
-	 * The column used for update timestamps
-	 *
-	 * @var string
-	 */
-	protected $updatedField = 'updated_at';
-
-	/**
-	 * Used by withDeleted to override the
-	 * model's softDelete setting.
-	 *
-	 * @var boolean
-	 */
-	protected $tempUseSoftDeletes;
-
-	/**
-	 * The column used to save soft delete state
-	 *
-	 * @var string
-	 */
-	protected $deletedField = 'deleted_at';
-
-	/**
-	 * Used by asArray and asObject to provide
-	 * temporary overrides of model default.
-	 *
-	 * @var string
-	 */
-	protected $tempReturnType;
-
-	/**
-	 * Whether we should limit fields in inserts
-	 * and updates to those available in $allowedFields or not.
-	 *
-	 * @var boolean
-	 */
-	protected $protectFields = true;
 
 	/**
 	 * Database Connection
@@ -196,153 +82,16 @@ class Model
 	protected $builder;
 
 	/**
-	 * Rules used to validate data in insert, update, and save methods.
-	 * The array must match the format of data passed to the Validation
-	 * library.
-	 *
-	 * @var array|string
-	 */
-	protected $validationRules = [];
-
-	/**
-	 * Contains any custom error messages to be
-	 * used during data validation.
-	 *
-	 * @var array
-	 */
-	protected $validationMessages = [];
-
-	/**
-	 * Skip the model's validation. Used in conjunction with skipValidation()
-	 * to skip data validation for any future calls.
-	 *
-	 * @var boolean
-	 */
-	protected $skipValidation = false;
-
-	/**
-	 * Whether rules should be removed that do not exist
-	 * in the passed in data. Used between inserts/updates.
-	 *
-	 * @var boolean
-	 */
-	protected $cleanValidationRules = true;
-
-	/**
-	 * Our validator instance.
-	 *
-	 * @var ValidationInterface
-	 */
-	protected $validation;
-
-	/*
-	 * Callbacks.
-	 *
-	 * Each array should contain the method names (within the model)
-	 * that should be called when those events are triggered.
-	 *
-	 * "Update" and "delete" methods are passed the same items that
-	 * are given to their respective method.
-	 *
-	 * "Find" methods receive the ID searched for (if present), and
-	 * 'afterFind' additionally receives the results that were found.
-	 */
-
-	/**
-	 * Whether to trigger the defined callbacks
-	 *
-	 * @var boolean
-	 */
-	protected $allowCallbacks = true;
-
-	/**
-	 * Used by allowCallbacks() to override the
-	 * model's allowCallbacks setting.
-	 *
-	 * @var boolean
-	 */
-	protected $tempAllowCallbacks;
-
-	/**
-	 * Callbacks for beforeInsert
-	 *
-	 * @var array
-	 */
-	protected $beforeInsert = [];
-
-	/**
-	 * Callbacks for afterInsert
-	 *
-	 * @var array
-	 */
-	protected $afterInsert = [];
-
-	/**
-	 * Callbacks for beforeUpdate
-	 *
-	 * @var array
-	 */
-	protected $beforeUpdate = [];
-
-	/**
-	 * Callbacks for afterUpdate
-	 *
-	 * @var array
-	 */
-	protected $afterUpdate = [];
-
-	/**
-	 * Callbacks for beforeFind
-	 *
-	 * @var array
-	 */
-	protected $beforeFind = [];
-
-	/**
-	 * Callbacks for afterFind
-	 *
-	 * @var array
-	 */
-	protected $afterFind = [];
-
-	/**
-	 * Callbacks for beforeDelete
-	 *
-	 * @var array
-	 */
-	protected $beforeDelete = [];
-
-	/**
-	 * Callbacks for afterDelete
-	 *
-	 * @var array
-	 */
-	protected $afterDelete = [];
-
-	/**
-	 * Holds information passed in via 'set'
-	 * so that we can capture it (not the builder)
-	 * and ensure it gets validated first.
-	 *
-	 * @var array
-	 */
-	protected $tempData = [];
-
-	/**
 	 * Model constructor.
 	 *
-	 * @param ConnectionInterface|null $db
-	 * @param ValidationInterface|null $validation
+	 * @param ConnectionInterface|null $db         DB Connection
+	 * @param ValidationInterface|null $validation Validation
 	 */
 	public function __construct(ConnectionInterface &$db = null, ValidationInterface $validation = null)
 	{
-		$db = $db ?? Database::connect($this->DBGroup);
+		parent::__construct($db, $validation);
 
-		$this->db                 = &$db;
-		$this->tempReturnType     = $this->returnType;
-		$this->tempUseSoftDeletes = $this->useSoftDeletes;
-		$this->tempAllowCallbacks = $this->allowCallbacks;
-		$this->validation         = $validation ?? Services::validation(null, false);
+		$this->db = $db ?? Database::connect($this->DBGroup);
 	}
 
 	//--------------------------------------------------------------------
@@ -351,31 +100,15 @@ class Model
 
 	/**
 	 * Fetches the row of database from $this->table with a primary key
-	 * matching $id.
+	 * matching $id. This methods works only with dbCalls
 	 *
-	 * @param array|integer|string|null $id One primary key or an array of primary keys
+	 * @param boolean                   $singleton Single or multiple results
+	 * @param array|integer|string|null $id        One primary key or an array of primary keys
 	 *
 	 * @return array|object|null    The resulting row of data, or null.
 	 */
-	public function find($id = null)
+	protected function _find(bool $singleton, $id = null)
 	{
-		$singleton = is_numeric($id) || is_string($id);
-
-		if ($this->tempAllowCallbacks)
-		{
-			// Call the before event and check for a return
-			$eventData = $this->trigger('beforeFind', [
-				'id'        => $id,
-				'method'    => 'find',
-				'singleton' => $singleton,
-			]);
-
-			if (! empty($eventData['returnData']))
-			{
-				return $eventData['data'];
-			}
-		}
-
 		$builder = $this->builder();
 
 		if ($this->tempUseSoftDeletes)
@@ -400,72 +133,32 @@ class Model
 			$row = $builder->get()->getResult($this->tempReturnType);
 		}
 
-		$eventData = [
-			'id'        => $id,
-			'data'      => $row,
-			'method'    => 'find',
-			'singleton' => $singleton,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$eventData = $this->trigger('afterFind', $eventData);
-		}
-
-		$this->tempReturnType     = $this->returnType;
-		$this->tempUseSoftDeletes = $this->useSoftDeletes;
-		$this->tempAllowCallbacks = $this->allowCallbacks;
-
-		return $eventData['data'];
+		return $row;
 	}
 
 	/**
 	 * Fetches the column of database from $this->table
 	 *
-	 * @param string $columnName
+	 * @param string $columnName Column Name
 	 *
 	 * @return array|null   The resulting row of data, or null if no data found.
-	 * @throws DataException
 	 */
-	public function findColumn(string $columnName)
+	protected function _findColumn(string $columnName)
 	{
-		if (strpos($columnName, ',') !== false)
-		{
-			throw DataException::forFindColumnHaveMultipleColumns();
-		}
-
-		$resultSet = $this->select($columnName)->asArray()->find();
-
-		return $resultSet ? array_column($resultSet, $columnName) : null;
+		return $this->select($columnName)->asArray()->find();
 	}
 
 	/**
 	 * Works with the current Query Builder instance to return
 	 * all results, while optionally limiting them.
 	 *
-	 * @param integer $limit
-	 * @param integer $offset
+	 * @param integer $limit  Limit
+	 * @param integer $offset Offset
 	 *
 	 * @return array
 	 */
-	public function findAll(int $limit = 0, int $offset = 0)
+	protected function _findAll(int $limit = 0, int $offset = 0)
 	{
-		if ($this->tempAllowCallbacks)
-		{
-			// Call the before event and check for a return
-			$eventData = $this->trigger('beforeFind', [
-				'method'    => 'findAll',
-				'limit'     => $limit,
-				'offset'    => $offset,
-				'singleton' => false,
-			]);
-
-			if (! empty($eventData['returnData']))
-			{
-				return $eventData['data'];
-			}
-		}
-
 		$builder = $this->builder();
 
 		if ($this->tempUseSoftDeletes)
@@ -473,28 +166,9 @@ class Model
 			$builder->where($this->table . '.' . $this->deletedField, null);
 		}
 
-		$row = $builder->limit($limit, $offset)
-				->get()
-				->getResult($this->tempReturnType);
-
-		$eventData = [
-			'data'      => $row,
-			'limit'     => $limit,
-			'offset'    => $offset,
-			'method'    => 'findAll',
-			'singleton' => false,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$eventData = $this->trigger('afterFind', $eventData);
-		}
-
-		$this->tempReturnType     = $this->returnType;
-		$this->tempUseSoftDeletes = $this->useSoftDeletes;
-		$this->tempAllowCallbacks = $this->allowCallbacks;
-
-		return $eventData['data'];
+		return $builder->limit($limit, $offset)
+			->get()
+			->getResult($this->tempReturnType);
 	}
 
 	/**
@@ -503,22 +177,8 @@ class Model
 	 *
 	 * @return array|object|null
 	 */
-	public function first()
+	protected function _first()
 	{
-		if ($this->tempAllowCallbacks)
-		{
-			// Call the before event and check for a return
-			$eventData = $this->trigger('beforeFind', [
-				'method'    => 'first',
-				'singleton' => true,
-			]);
-
-			if (! empty($eventData['returnData']))
-			{
-				return $eventData['data'];
-			}
-		}
-
 		$builder = $this->builder();
 
 		if ($this->tempUseSoftDeletes)
@@ -540,43 +200,7 @@ class Model
 			$builder->orderBy($this->table . '.' . $this->primaryKey, 'asc');
 		}
 
-		$eventData = [
-			'data'      => $builder->limit(1, 0)->get()->getFirstRow($this->tempReturnType),
-			'method'    => 'first',
-			'singleton' => true,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$eventData = $this->trigger('afterFind', $eventData);
-		}
-
-		$this->tempReturnType     = $this->returnType;
-		$this->tempUseSoftDeletes = $this->useSoftDeletes;
-		$this->tempAllowCallbacks = $this->allowCallbacks;
-
-		return $eventData['data'];
-	}
-
-	/**
-	 * Captures the builder's set() method so that we can validate the
-	 * data here. This allows it to be used with any of the other
-	 * builder methods and still get validated data, like replace.
-	 *
-	 * @param mixed   $key    Field name, or an array of field/value pairs
-	 * @param string  $value  Field value, if $key is a single field
-	 * @param boolean $escape Whether to escape values and identifiers
-	 *
-	 * @return $this
-	 */
-	public function set($key, ?string $value = '', bool $escape = null)
-	{
-		$data = is_array($key) ? $key : [$key => $value];
-
-		$this->tempData['escape'] = $escape;
-		$this->tempData['data']   = array_merge($this->tempData['data'] ?? [], $data);
-
-		return $this;
+		return $builder->limit(1, 0)->get()->getFirstRow($this->tempReturnType);
 	}
 
 	/**
@@ -586,18 +210,12 @@ class Model
 	 * you must ensure that the class will provide access to the class
 	 * variables, even if through a magic method.
 	 *
-	 * @param array|object $data
+	 * @param array|object $data Data
 	 *
 	 * @return boolean
-	 * @throws ReflectionException
 	 */
-	public function save($data): bool
+	protected function _save($data): bool
 	{
-		if (empty($data))
-		{
-			return true;
-		}
-
 		// When useAutoIncrement feature is disabled check
 		// in the database if given record already exists
 		if (! $makeUpdate = $this->useAutoIncrement)
@@ -640,180 +258,30 @@ class Model
 				$response = true;
 			}
 		}
-
 		return $response;
-	}
-
-	/**
-	 * Takes a class an returns an array of it's public and protected
-	 * properties as an array suitable for use in creates and updates.
-	 *
-	 * @param string|object $data
-	 * @param string|null   $primaryKey
-	 * @param string        $dateFormat
-	 * @param boolean       $onlyChanged
-	 *
-	 * @return array
-	 * @throws ReflectionException
-	 */
-	public static function classToArray($data, $primaryKey = null, string $dateFormat = 'datetime', bool $onlyChanged = true): array
-	{
-		if (method_exists($data, 'toRawArray'))
-		{
-			$properties = $data->toRawArray($onlyChanged);
-
-			// Always grab the primary key otherwise updates will fail.
-			if (! empty($properties) && ! empty($primaryKey) && ! in_array($primaryKey, $properties, true) && ! empty($data->{$primaryKey}))
-			{
-				$properties[$primaryKey] = $data->{$primaryKey};
-			}
-		}
-		else
-		{
-			$mirror = new ReflectionClass($data);
-			$props  = $mirror->getProperties(ReflectionProperty::IS_PUBLIC | ReflectionProperty::IS_PROTECTED);
-
-			$properties = [];
-
-			// Loop over each property,
-			// saving the name/value in a new array we can return.
-			foreach ($props as $prop)
-			{
-				// Must make protected values accessible.
-				$prop->setAccessible(true);
-				$properties[$prop->getName()] = $prop->getValue($data);
-			}
-		}
-
-		// Convert any Time instances to appropriate $dateFormat
-		if ($properties)
-		{
-			foreach ($properties as $key => $value)
-			{
-				if ($value instanceof Time)
-				{
-					switch ($dateFormat)
-					{
-						case 'datetime':
-							$converted = $value->format('Y-m-d H:i:s');
-							break;
-						case 'date':
-							$converted = $value->format('Y-m-d');
-							break;
-						case 'int':
-							$converted = $value->getTimestamp();
-							break;
-						default:
-							$converted = (string) $value;
-					}
-
-					$properties[$key] = $converted;
-				}
-			}
-		}
-
-		return $properties;
-	}
-
-	/**
-	 * Returns last insert ID or 0.
-	 *
-	 * @return integer|string
-	 */
-	public function getInsertID()
-	{
-		return is_numeric($this->insertID) ? (int) $this->insertID : $this->insertID;
 	}
 
 	/**
 	 * Inserts data into the current table. If an object is provided,
 	 * it will attempt to convert it to an array.
 	 *
-	 * @param array|object $data
-	 * @param boolean      $returnID Whether insert ID should be returned or not.
+	 * @param array|object $data   Data
+	 * @param boolean|null $escape Escape
 	 *
 	 * @return BaseResult|integer|string|false
-	 * @throws ReflectionException
 	 */
-	public function insert($data = null, bool $returnID = true)
+	protected function _insert($data, bool $escape = null)
 	{
-		$escape = null;
-
-		$this->insertID = 0;
-
-		if (empty($data))
-		{
-			$data           = $this->tempData['data'] ?? null;
-			$escape         = $this->tempData['escape'] ?? null;
-			$this->tempData = [];
-		}
-
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('insert');
-		}
-
-		// If $data is using a custom class with public or protected
-		// properties representing the table elements, we need to grab
-		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
-			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat, false);
-		}
-
-		// If it's still a stdClass, go ahead and convert to
-		// an array so doProtectFields and other model methods
-		// don't have to do special checks.
-		if (is_object($data))
-		{
-			$data = (array) $data;
-		}
-
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('insert');
-		}
-
-		// Validate data before saving.
-		if (! $this->skipValidation && ! $this->cleanRules()->validate($data))
-		{
-			return false;
-		}
-
-		// Must be called first so we don't
-		// strip out created_at values.
-		$data = $this->doProtectFields($data);
-
-		// Set created_at and updated_at with same time
-		$date = $this->setDate();
-
-		if ($this->useTimestamps && $this->createdField && ! array_key_exists($this->createdField, $data))
-		{
-			$data[$this->createdField] = $date;
-		}
-
-		if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $data))
-		{
-			$data[$this->updatedField] = $date;
-		}
-
-		$eventData = ['data' => $data];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$eventData = $this->trigger('beforeInsert', $eventData);
-		}
-
 		// Require non empty primaryKey when
 		// not using auto-increment feature
-		if (! $this->useAutoIncrement && empty($eventData['data'][$this->primaryKey]))
+		if (! $this->useAutoIncrement && empty($data[$this->primaryKey]))
 		{
 			throw DataException::forEmptyPrimaryKey('insert');
 		}
 
 		// Must use the set() method to ensure objects get converted to arrays
 		$result = $this->builder()
-			->set($eventData['data'], '', $escape)
+			->set($data, '', $escape)
 			->insert();
 
 		// If insertion succeeded then save the insert ID
@@ -821,7 +289,7 @@ class Model
 		{
 			if (! $this->useAutoIncrement)
 			{
-				$this->insertID = $eventData['data'][$this->primaryKey];
+				$this->insertID = $data[$this->primaryKey];
 			}
 			else
 			{
@@ -829,90 +297,36 @@ class Model
 			}
 		}
 
-		$eventData = [
-			'id'     => $this->insertID,
-			'data'   => $eventData['data'],
-			'result' => $result,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			// Trigger afterInsert events with the inserted data and new ID
-			$this->trigger('afterInsert', $eventData);
-		}
-
-		$this->tempAllowCallbacks = $this->allowCallbacks;
-
-		// If insertion failed, get out of here
-		if (! $result)
-		{
-			return $result;
-		}
-
-		// otherwise return the insertID, if requested.
-		return $returnID ? $this->insertID : $result;
+		return $result;
 	}
 
 	/**
 	 * Compiles batch insert strings and runs the queries, validating each row prior.
 	 *
-	 * @param array   $set       An associative array of insert values
-	 * @param boolean $escape    Whether to escape values and identifiers
-	 * @param integer $batchSize The size of the batch to run
-	 * @param boolean $testing   True means only number of records is returned, false will execute the query
+	 * @param array|null $set       An associative array of insert values
+	 * @param boolean    $escape    Whether to escape values and identifiers
+	 * @param integer    $batchSize The size of the batch to run
+	 * @param boolean    $testing   True means only number of records is returned, false will execute the query
 	 *
 	 * @return integer|boolean Number of rows inserted or FALSE on failure
+	 * @throws ReflectionException ReflectionException.
 	 */
-	public function insertBatch(array $set = null, bool $escape = null, int $batchSize = 100, bool $testing = false)
+	protected function _insertBatch(
+		array $set = null,
+		bool $escape = null,
+		int $batchSize = 100,
+		bool $testing = false
+	)
 	{
 		if (is_array($set))
 		{
 			foreach ($set as &$row)
 			{
-				// If $data is using a custom class with public or protected
-				// properties representing the table elements, we need to grab
-				// them as an array.
-				if (is_object($row) && ! $row instanceof stdClass)
-				{
-					$row = static::classToArray($row, $this->primaryKey, $this->dateFormat, false);
-				}
-
-				// If it's still a stdClass, go ahead and convert to
-				// an array so doProtectFields and other model methods
-				// don't have to do special checks.
-				if (is_object($row))
-				{
-					$row = (array) $row;
-				}
-
-				// Validate every row..
-				if (! $this->skipValidation && ! $this->cleanRules()->validate($row))
-				{
-					return false;
-				}
-
-				// Must be called first so we don't
-				// strip out created_at values.
-				$row = $this->doProtectFields($row);
-
 				// Require non empty primaryKey when
 				// not using auto-increment feature
 				if (! $this->useAutoIncrement && empty($row[$this->primaryKey]))
 				{
 					throw DataException::forEmptyPrimaryKey('insertBatch');
-				}
-
-				// Set created_at and updated_at with same time
-				$date = $this->setDate();
-
-				if ($this->useTimestamps && $this->createdField && ! array_key_exists($this->createdField, $row))
-				{
-					$row[$this->createdField] = $date;
-				}
-
-				if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $row))
-				{
-					$row[$this->updatedField] = $date;
 				}
 			}
 		}
@@ -924,80 +338,14 @@ class Model
 	 * Updates a single record in $this->table. If an object is provided,
 	 * it will attempt to convert it into an array.
 	 *
-	 * @param integer|array|string|null $id
-	 * @param array|object|null         $data
+	 * @param integer|array|string|null $id     ID
+	 * @param array|object|null         $data   Data
+	 * @param boolean|null              $escape Escape
 	 *
 	 * @return boolean
-	 * @throws ReflectionException
 	 */
-	public function update($id = null, $data = null): bool
+	protected function _update($id = null, $data = null, ?bool $escape = null): bool
 	{
-		$escape = null;
-
-		if (is_numeric($id) || is_string($id))
-		{
-			$id = [$id];
-		}
-
-		if (empty($data))
-		{
-			$data           = $this->tempData['data'] ?? null;
-			$escape         = $this->tempData['escape'] ?? null;
-			$this->tempData = [];
-		}
-
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('update');
-		}
-
-		// If $data is using a custom class with public or protected
-		// properties representing the table elements, we need to grab
-		// them as an array.
-		if (is_object($data) && ! $data instanceof stdClass)
-		{
-			$data = static::classToArray($data, $this->primaryKey, $this->dateFormat);
-		}
-
-		// If it's still a stdClass, go ahead and convert to
-		// an array so doProtectFields and other model methods
-		// don't have to do special checks.
-		if (is_object($data))
-		{
-			$data = (array) $data;
-		}
-
-		// If it's still empty here, means $data is no change or is empty object
-		if (empty($data))
-		{
-			throw DataException::forEmptyDataset('update');
-		}
-
-		// Validate data before saving.
-		if (! $this->skipValidation && ! $this->cleanRules(true)->validate($data))
-		{
-			return false;
-		}
-
-		// Must be called first so we don't
-		// strip out updated_at values.
-		$data = $this->doProtectFields($data);
-
-		if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $data))
-		{
-			$data[$this->updatedField] = $this->setDate();
-		}
-
-		$eventData = [
-			'id'   => $id,
-			'data' => $data,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$eventData = $this->trigger('beforeUpdate', $eventData);
-		}
-
 		$builder = $this->builder();
 
 		if ($id)
@@ -1006,24 +354,9 @@ class Model
 		}
 
 		// Must use the set() method to ensure objects get converted to arrays
-		$result = $builder
-			->set($eventData['data'], '', $escape)
+		return $builder
+			->set($data, '', $escape)
 			->update();
-
-		$eventData = [
-			'id'     => $id,
-			'data'   => $eventData['data'],
-			'result' => $result,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$this->trigger('afterUpdate', $eventData);
-		}
-
-		$this->tempAllowCallbacks = $this->allowCallbacks;
-
-		return $result;
 	}
 
 	/**
@@ -1031,62 +364,22 @@ class Model
 	 *
 	 * Compiles an update string and runs the query
 	 *
-	 * @param array   $set       An associative array of update values
-	 * @param string  $index     The where key
-	 * @param integer $batchSize The size of the batch to run
-	 * @param boolean $returnSQL True means SQL is returned, false will execute the query
+	 * @param array|null  $set       An associative array of update values
+	 * @param string|null $index     The where key
+	 * @param integer     $batchSize The size of the batch to run
+	 * @param boolean     $returnSQL True means SQL is returned, false will execute the query
 	 *
 	 * @return mixed    Number of rows affected or FALSE on failure
-	 * @throws DatabaseException
+	 * @throws DatabaseException DatabaseException.
+	 * @throws ReflectionException ReflectionException.
 	 */
-	public function updateBatch(array $set = null, string $index = null, int $batchSize = 100, bool $returnSQL = false)
+	protected function _updateBatch(
+		array $set = null,
+		string $index = null,
+		int $batchSize = 100,
+		bool $returnSQL = false
+	)
 	{
-		if (is_array($set))
-		{
-			foreach ($set as &$row)
-			{
-				// If $data is using a custom class with public or protected
-				// properties representing the table elements, we need to grab
-				// them as an array.
-				if (is_object($row) && ! $row instanceof stdClass)
-				{
-					$row = static::classToArray($row, $this->primaryKey, $this->dateFormat);
-				}
-
-				// If it's still a stdClass, go ahead and convert to
-				// an array so doProtectFields and other model methods
-				// don't have to do special checks.
-				if (is_object($row))
-				{
-					$row = (array) $row;
-				}
-
-				// Validate data before saving.
-				if (! $this->skipValidation && ! $this->cleanRules(true)->validate($row))
-				{
-					return false;
-				}
-
-				// Save updateIndex for later
-				$updateIndex = $row[$index] ?? null;
-
-				// Must be called first so we don't
-				// strip out updated_at values.
-				$row = $this->doProtectFields($row);
-
-				// Restore updateIndex value in case it was wiped out
-				if ($updateIndex !== null)
-				{
-					$row[$index] = $updateIndex;
-				}
-
-				if ($this->useTimestamps && $this->updatedField && ! array_key_exists($this->updatedField, $row))
-				{
-					$row[$this->updatedField] = $this->setDate();
-				}
-			}
-		}
-
 		return $this->builder()->testMode($returnSQL)->updateBatch($set, $index, $batchSize);
 	}
 
@@ -1098,30 +391,15 @@ class Model
 	 * @param boolean                   $purge Allows overriding the soft deletes setting.
 	 *
 	 * @return BaseResult|boolean
-	 * @throws DatabaseException
+	 * @throws DatabaseException DatabaseException.
 	 */
-	public function delete($id = null, bool $purge = false)
+	protected function _delete($id = null, bool $purge = false)
 	{
-		if ($id && (is_numeric($id) || is_string($id)))
-		{
-			$id = [$id];
-		}
-
 		$builder = $this->builder();
 
 		if ($id)
 		{
 			$builder = $builder->whereIn($this->primaryKey, $id);
-		}
-
-		$eventData = [
-			'id'    => $id,
-			'purge' => $purge,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$this->trigger('beforeDelete', $eventData);
 		}
 
 		if ($this->useSoftDeletes && ! $purge)
@@ -1130,7 +408,9 @@ class Model
 			{
 				if (CI_DEBUG)
 				{
-					throw new DatabaseException('Deletes are not allowed unless they contain a "where" or "like" clause.');
+					throw new DatabaseException(
+						'Deletes are not allowed unless they contain a "where" or "like" clause.'
+					);
 				}
 
 				return false; // @codeCoverageIgnore
@@ -1150,20 +430,6 @@ class Model
 			$result = $builder->delete();
 		}
 
-		$eventData = [
-			'id'     => $id,
-			'purge'  => $purge,
-			'result' => $result,
-			'data'   => null,
-		];
-
-		if ($this->tempAllowCallbacks)
-		{
-			$this->trigger('afterDelete', $eventData);
-		}
-
-		$this->tempAllowCallbacks = $this->allowCallbacks;
-
 		return $result;
 	}
 
@@ -1173,45 +439,22 @@ class Model
 	 *
 	 * @return boolean|mixed
 	 */
-	public function purgeDeleted()
+	protected function _purgeDeleted()
 	{
-		if (! $this->useSoftDeletes)
-		{
-			return true;
-		}
-
 		return $this->builder()
 			->where($this->table . '.' . $this->deletedField . ' IS NOT NULL')
 			->delete();
 	}
 
 	/**
-	 * Sets $useSoftDeletes value so that we can temporarily override
-	 * the softdeletes settings. Can be used for all find* methods.
-	 *
-	 * @param boolean $val
-	 *
-	 * @return $this
-	 */
-	public function withDeleted(bool $val = true)
-	{
-		$this->tempUseSoftDeletes = ! $val;
-
-		return $this;
-	}
-
-	/**
 	 * Works with the find* methods to return only the rows that
 	 * have been deleted.
 	 *
-	 * @return $this
+	 * @return void
 	 */
-	public function onlyDeleted()
+	protected function _onlyDeleted()
 	{
-		$this->tempUseSoftDeletes = false;
 		$this->builder()->where($this->table . '.' . $this->deletedField . ' IS NOT NULL');
-
-		return $this;
 	}
 
 	/**
@@ -1219,19 +462,13 @@ class Model
 	 *
 	 * Compiles a replace into string and runs the query
 	 *
-	 * @param array|null $data
-	 * @param boolean    $returnSQL
+	 * @param array|null $data      Data
+	 * @param boolean    $returnSQL Set to true to return Query String
 	 *
 	 * @return mixed
 	 */
-	public function replace(array $data = null, bool $returnSQL = false)
+	protected function _replace(array $data = null, bool $returnSQL = false)
 	{
-		// Validate data before saving.
-		if ($data && ! $this->skipValidation && ! $this->cleanRules(true)->validate($data))
-		{
-			return false;
-		}
-
 		return $this->builder()->testMode($returnSQL)->replace($data);
 	}
 
@@ -1240,43 +477,16 @@ class Model
 	//--------------------------------------------------------------------
 
 	/**
-	 * Sets the return type of the results to be as an associative array.
-	 *
-	 * @return $this
-	 */
-	public function asArray()
-	{
-		$this->tempReturnType = 'array';
-
-		return $this;
-	}
-
-	/**
-	 * Sets the return type to be of the specified type of object.
-	 * Defaults to a simple object, but can be any class that has
-	 * class vars with the same name as the table columns, or at least
-	 * allows them to be created.
-	 *
-	 * @param string $class
-	 *
-	 * @return $this
-	 */
-	public function asObject(string $class = 'object')
-	{
-		$this->tempReturnType = $class;
-
-		return $this;
-	}
-
-	/**
 	 * Loops over records in batches, allowing you to operate on them.
 	 * Works with $this->builder to get the Compiled select to
 	 * determine the rows to operate on.
 	 *
-	 * @param integer $size
-	 * @param Closure $userFunc
+	 * @param integer $size     Size
+	 * @param Closure $userFunc Callback Function
 	 *
-	 * @throws DataException
+	 * @throws DataException DataException.
+	 *
+	 * @return void
 	 */
 	public function chunk(int $size, Closure $userFunc)
 	{
@@ -1310,54 +520,6 @@ class Model
 				}
 			}
 		}
-	}
-
-	/**
-	 * Works with $this->builder to get the Compiled Select to operate on.
-	 * Expects a GET variable (?page=2) that specifies the page of results
-	 * to display.
-	 *
-	 * @param integer|null $perPage
-	 * @param string       $group   Will be used by the pagination library to identify a unique pagination set.
-	 * @param integer|null $page    Optional page number (useful when the page number is provided in different way)
-	 * @param integer      $segment Optional URI segment number (if page number is provided by URI segment)
-	 *
-	 * @return array|null
-	 */
-	public function paginate(int $perPage = null, string $group = 'default', int $page = null, int $segment = 0)
-	{
-		$pager = Services::pager(null, null, false);
-
-		if ($segment)
-		{
-			$pager->setSegment($segment);
-		}
-
-		$page  = $page >= 1 ? $page : $pager->getCurrentPage($group);
-		$total = $this->countAllResults(false);
-
-		// Store it in the Pager library so it can be
-		// paginated in the views.
-		$this->pager = $pager->store($group, $page, $perPage, $total, $segment);
-		$perPage     = $this->pager->getPerPage($group);
-		$offset      = ($page - 1) * $perPage;
-
-		return $this->findAll($perPage, $offset);
-	}
-
-	/**
-	 * Sets whether or not we should whitelist data set during
-	 * updates or inserts against $this->availableFields.
-	 *
-	 * @param boolean $protect
-	 *
-	 * @return $this
-	 */
-	public function protect(bool $protect = true)
-	{
-		$this->protectFields = $protect;
-
-		return $this;
 	}
 
 	/**
@@ -1410,397 +572,20 @@ class Model
 	}
 
 	/**
-	 * Ensures that only the fields that are allowed to be updated
-	 * are in the data array.
-	 *
-	 * Used by insert() and update() to protect against mass assignment
-	 * vulnerabilities.
-	 *
-	 * @param array $data
-	 *
-	 * @return array
-	 * @throws DataException
-	 */
-	protected function doProtectFields(array $data): array
-	{
-		if (! $this->protectFields)
-		{
-			return $data;
-		}
-
-		if (empty($this->allowedFields))
-		{
-			throw DataException::forInvalidAllowedFields(get_class($this));
-		}
-
-		foreach ($data as $key => $val)
-		{
-			if (! in_array($key, $this->allowedFields, true))
-			{
-				unset($data[$key]);
-			}
-		}
-
-		return $data;
-	}
-
-	/**
-	 * A utility function to allow child models to use the type of
-	 * date/time format that they prefer. This is primarily used for
-	 * setting created_at, updated_at and deleted_at values, but can be
-	 * used by inheriting classes.
-	 *
-	 * The available time formats are:
-	 *  - 'int'      - Stores the date as an integer timestamp
-	 *  - 'datetime' - Stores the data in the SQL datetime format
-	 *  - 'date'     - Stores the date (only) in the SQL date format.
-	 *
-	 * @param integer $userData An optional PHP timestamp to be converted.
-	 *
-	 * @return mixed
-	 * @throws ModelException ;
-	 */
-	protected function setDate(int $userData = null)
-	{
-		$currentDate = $userData ?? time();
-
-		switch ($this->dateFormat)
-		{
-			case 'int':
-				return $currentDate;
-			case 'datetime':
-				return date('Y-m-d H:i:s', $currentDate);
-			case 'date':
-				return date('Y-m-d', $currentDate);
-			default:
-				throw ModelException::forNoDateFormat(static::class);
-		}
-	}
-
-	/**
-	 * Specify the table associated with a model
-	 *
-	 * @param string $table
-	 *
-	 * @return $this
-	 */
-	public function setTable(string $table)
-	{
-		$this->table = $table;
-
-		return $this;
-	}
-
-	/**
-	 * Grabs the last error(s) that occurred. If data was validated,
-	 * it will first check for errors there, otherwise will try to
-	 * grab the last error from the Database connection.
-	 *
-	 * @param boolean $forceDB Always grab the db error, not validation
+	 * Grabs the last error(s) that occurred from the Database connection.
 	 *
 	 * @return array|null
 	 */
-	public function errors(bool $forceDB = false)
+	protected function _errors()
 	{
-		// Do we have validation errors?
-		if (! $forceDB && ! $this->skipValidation)
-		{
-			$errors = $this->validation->getErrors();
-
-			if (! empty($errors))
-			{
-				return $errors;
-			}
-		}
-
-		$error = $this->db->error();
-
-		return $error['message'] ?? null;
-	}
-
-	/**
-	 * It could be used when you have to change default or override current allowed fields.
-	 *
-	 * @param array $allowedFields
-	 *
-	 * @return $this
-	 */
-	public function setAllowedFields(array $allowedFields)
-	{
-		$this->allowedFields = $allowedFields;
-
-		return $this;
-	}
-
-	//--------------------------------------------------------------------
-	// Validation
-	//--------------------------------------------------------------------
-
-	/**
-	 * Set the value of the skipValidation flag.
-	 *
-	 * @param boolean $skip
-	 *
-	 * @return $this
-	 */
-	public function skipValidation(bool $skip = true)
-	{
-		$this->skipValidation = $skip;
-
-		return $this;
-	}
-
-	/**
-	 * Allows to set validation messages.
-	 * It could be used when you have to change default or override current validate messages.
-	 *
-	 * @param array $validationMessages
-	 *
-	 * @return $this
-	 */
-	public function setValidationMessages(array $validationMessages)
-	{
-		$this->validationMessages = $validationMessages;
-
-		return $this;
-	}
-
-	/**
-	 * Allows to set field wise validation message.
-	 * It could be used when you have to change default or override current validate messages.
-	 *
-	 * @param string $field
-	 * @param array  $fieldMessages
-	 *
-	 * @return $this
-	 */
-	public function setValidationMessage(string $field, array $fieldMessages)
-	{
-		$this->validationMessages[$field] = $fieldMessages;
-
-		return $this;
-	}
-
-	/**
-	 * Allows to set validation rules.
-	 * It could be used when you have to change default or override current validate rules.
-	 *
-	 * @param array $validationRules
-	 *
-	 * @return $this
-	 */
-	public function setValidationRules(array $validationRules)
-	{
-		$this->validationRules = $validationRules;
-
-		return $this;
-	}
-
-	/**
-	 * Allows to set field wise validation rules.
-	 * It could be used when you have to change default or override current validate rules.
-	 *
-	 * @param string       $field
-	 * @param string|array $fieldRules
-	 *
-	 * @return $this
-	 */
-	public function setValidationRule(string $field, $fieldRules)
-	{
-		$this->validationRules[$field] = $fieldRules;
-
-		return $this;
-	}
-
-	/**
-	 * Should validation rules be removed before saving?
-	 * Most handy when doing updates.
-	 *
-	 * @param boolean $choice
-	 *
-	 * @return $this
-	 */
-	public function cleanRules(bool $choice = false)
-	{
-		$this->cleanValidationRules = $choice;
-
-		return $this;
-	}
-
-	/**
-	 * Validate the data against the validation rules (or the validation group)
-	 * specified in the class property, $validationRules.
-	 *
-	 * @param array|object $data
-	 *
-	 * @return boolean
-	 */
-	public function validate($data): bool
-	{
-		$rules = $this->getValidationRules();
-
-		if ($this->skipValidation || empty($rules) || empty($data))
-		{
-			return true;
-		}
-
-		// Query Builder works with objects as well as arrays,
-		// but validation requires array, so cast away.
-		if (is_object($data))
-		{
-			$data = (array) $data;
-		}
-
-		$rules = $this->cleanValidationRules ? $this->cleanValidationRules($rules, $data) : $rules;
-
-		// If no data existed that needs validation
-		// our job is done here.
-		if (empty($rules))
-		{
-			return true;
-		}
-
-		return $this->validation
-			->setRules($rules, $this->validationMessages)
-			->run($data, null, $this->DBGroup);
-	}
-
-	/**
-	 * Removes any rules that apply to fields that have not been set
-	 * currently so that rules don't block updating when only updating
-	 * a partial row.
-	 *
-	 * @param array      $rules
-	 * @param array|null $data
-	 *
-	 * @return array
-	 */
-	protected function cleanValidationRules(array $rules, array $data = null): array
-	{
-		if (empty($data))
-		{
-			return [];
-		}
-
-		foreach ($rules as $field => $rule)
-		{
-			if (! array_key_exists($field, $data))
-			{
-				unset($rules[$field]);
-			}
-		}
-
-		return $rules;
-	}
-
-	/**
-	 * Replace any placeholders within the rules with the values that
-	 * match the 'key' of any properties being set. For example, if
-	 * we had the following $data array:
-	 *
-	 * [ 'id' => 13 ]
-	 *
-	 * and the following rule:
-	 *
-	 *  'required|is_unique[users,email,id,{id}]'
-	 *
-	 * The value of {id} would be replaced with the actual id in the form data:
-	 *
-	 *  'required|is_unique[users,email,id,13]'
-	 *
-	 * @codeCoverageIgnore
-	 *
-	 * @deprecated use fillPlaceholders($rules, $data) from Validation instead
-	 *
-	 * @param array $rules
-	 * @param array $data
-	 *
-	 * @return array
-	 */
-	protected function fillPlaceholders(array $rules, array $data): array
-	{
-		$replacements = [];
-
-		foreach ($data as $key => $value)
-		{
-			$replacements["{{$key}}"] = $value;
-		}
-
-		if (! empty($replacements))
-		{
-			foreach ($rules as &$rule)
-			{
-				if (is_array($rule))
-				{
-					foreach ($rule as &$row)
-					{
-						// Should only be an `errors` array
-						// which doesn't take placeholders.
-						if (is_array($row))
-						{
-							continue;
-						}
-
-						$row = strtr($row, $replacements);
-					}
-
-					continue;
-				}
-
-				$rule = strtr($rule, $replacements);
-			}
-		}
-
-		return $rules;
-	}
-
-	/**
-	 * Returns the model's defined validation rules so that they
-	 * can be used elsewhere, if needed.
-	 *
-	 * @param array $options
-	 *
-	 * @return array
-	 */
-	public function getValidationRules(array $options = []): array
-	{
-		$rules = $this->validationRules;
-
-		// ValidationRules can be either a string, which is the group name,
-		// or an array of rules.
-		if (is_string($rules))
-		{
-			$rules = $this->validation->loadRuleGroup($rules); // @phpstan-ignore-line
-		}
-
-		if (isset($options['except']))
-		{
-			$rules = array_diff_key($rules, array_flip($options['except']));
-		}
-		elseif (isset($options['only']))
-		{
-			$rules = array_intersect_key($rules, array_flip($options['only']));
-		}
-
-		return $rules;
-	}
-
-	/**
-	 * Returns the model's define validation messages so they
-	 * can be used elsewhere, if needed.
-	 *
-	 * @return array
-	 */
-	public function getValidationMessages(): array
-	{
-		return $this->validationMessages;
+		return $this->db->error();
 	}
 
 	/**
 	 * Override countAllResults to account for soft deleted accounts.
 	 *
-	 * @param boolean $reset
-	 * @param boolean $test
+	 * @param boolean $reset Reset
+	 * @param boolean $test  Test
 	 *
 	 * @return mixed
 	 */
@@ -1821,63 +606,6 @@ class Model
 		return $this->builder()->testMode($test)->countAllResults($reset);
 	}
 
-	/**
-	 * Sets $tempAllowCallbacks value so that we can temporarily override
-	 * the setting. Resets after the next method that uses triggers.
-	 *
-	 * @param boolean $val
-	 *
-	 * @return $this
-	 */
-	public function allowCallbacks(bool $val = true)
-	{
-		$this->tempAllowCallbacks = $val;
-
-		return $this;
-	}
-
-	/**
-	 * A simple event trigger for Model Events that allows additional
-	 * data manipulation within the model. Specifically intended for
-	 * usage by child models this can be used to format data,
-	 * save/load related classes, etc.
-	 *
-	 * It is the responsibility of the callback methods to return
-	 * the data itself.
-	 *
-	 * Each $eventData array MUST have a 'data' key with the relevant
-	 * data for callback methods (like an array of key/value pairs to insert
-	 * or update, an array of results, etc)
-	 *
-	 * If callbacks are not allowed then returns $eventData immediately.
-	 *
-	 * @param string $event
-	 * @param array  $eventData
-	 *
-	 * @return mixed
-	 * @throws DataException
-	 */
-	protected function trigger(string $event, array $eventData)
-	{
-		// Ensure it's a valid event
-		if (! isset($this->{$event}) || empty($this->{$event}))
-		{
-			return $eventData;
-		}
-
-		foreach ($this->{$event} as $callback)
-		{
-			if (! method_exists($this, $callback))
-			{
-				throw DataException::forInvalidMethodTriggered($callback);
-			}
-
-			$eventData = $this->{$callback}($eventData);
-		}
-
-		return $eventData;
-	}
-
 	//--------------------------------------------------------------------
 	// Magic
 	//--------------------------------------------------------------------
@@ -1885,20 +613,15 @@ class Model
 	/**
 	 * Provides/instantiates the builder/db connection and model's table/primary key names and return type.
 	 *
-	 * @param string $name
+	 * @param string $name Name
 	 *
 	 * @return mixed
 	 */
 	public function __get(string $name)
 	{
-		if (property_exists($this, $name))
+		if (parent::__isset($name))
 		{
-			return $this->$name;
-		}
-
-		if (isset($this->db->$name))
-		{
-			return $this->db->$name;
+			return parent::__get($name);
 		}
 
 		if (isset($this->builder()->$name))
@@ -1912,18 +635,13 @@ class Model
 	/**
 	 * Checks for the existence of properties across this model, builder, and db connection.
 	 *
-	 * @param string $name
+	 * @param string $name Name
 	 *
 	 * @return boolean
 	 */
 	public function __isset(string $name): bool
 	{
-		if (property_exists($this, $name))
-		{
-			return true;
-		}
-
-		if (isset($this->db->$name))
+		if (parent::__isset($name))
 		{
 			return true;
 		}
@@ -1940,20 +658,16 @@ class Model
 	 * Provides direct access to method in the builder (if available)
 	 * and the database connection.
 	 *
-	 * @param string $name
-	 * @param array  $params
+	 * @param string $name   Name
+	 * @param array  $params Params
 	 *
 	 * @return $this|null
 	 */
 	public function __call(string $name, array $params)
 	{
-		$result = null;
+		$result = parent::__call($name, $params);
 
-		if (method_exists($this->db, $name))
-		{
-			$result = $this->db->{$name}(...$params);
-		}
-		elseif (method_exists($builder = $this->builder(), $name))
+		if ($result === null && method_exists($builder = $this->builder(), $name))
 		{
 			$result = $builder->{$name}(...$params);
 		}
@@ -1964,17 +678,17 @@ class Model
 			{
 				$className = static::class;
 
-				throw new BadMethodCallException("Call to undefined method $className::$name");
+				throw new BadMethodCallException('Call to undefined method ' . $className . '::' . $name);
 			}
 
 			return $result;
 		}
 
-		if (! $result instanceof BaseBuilder)
+		if ($result instanceof BaseBuilder)
 		{
-			return $result;
+			return $this;
 		}
 
-		return $this;
+		return $result;
 	}
 }

--- a/system/Model.php
+++ b/system/Model.php
@@ -60,16 +60,6 @@ class Model extends BaseModel
 	protected $useAutoIncrement = true;
 
 	/**
-	 * The type of column that created_at and updated_at
-	 * are expected to.
-	 *
-	 * Allowed: 'datetime', 'date', 'int'
-	 *
-	 * @var string
-	 */
-	protected $dateFormat = 'datetime';
-
-	/**
 	 * Query Builder object
 	 *
 	 * @var BaseBuilder|null


### PR DESCRIPTION
**Description**
I am still looking at the specifics of the new `BaseModel` split. I started taking notes and a lot of them were around formatting so I thought I would go ahead and send those over to make that actual content changes easier to distinguish.

The `region` `endregion` I assume is an IDE thing. Since we don't use this syntax anywhere else I don't think it should be here. You can use the `//-----------` separators if you want visual divisions or just leave them off.

One functional thing I see accidentally made it in here: I think `Model::$db` will still have to be typed as `ConnectionInterface` for static analysis. Supplying the property again with the updated type I think should fix this.
